### PR TITLE
Implement notice card preview with navigation and sharing functionality

### DIFF
--- a/.changeset/tricky-papers-type.md
+++ b/.changeset/tricky-papers-type.md
@@ -1,0 +1,9 @@
+---
+"public": minor
+"@mcmec/ui": minor
+"notices": patch
+---
+
+Turned public notice card into a preview card with callbacks to navigate to notice page and share URL.
+Added a new route in public to display a notice.
+Modified design of notice route in notice manager.

--- a/apps/notices/src/routes/(app)/index.tsx
+++ b/apps/notices/src/routes/(app)/index.tsx
@@ -15,7 +15,7 @@ import {
 	EmptyTitle,
 } from "@mcmec/ui/components/empty";
 import { eq, lte, useLiveQuery } from "@tanstack/react-db";
-import { createFileRoute, Link } from "@tanstack/react-router";
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import { useState } from "react";
 import { useNotices } from "@/src/hooks/use-notices";
@@ -31,6 +31,7 @@ export const Route = createFileRoute("/(app)/")({
 });
 
 function RouteComponent() {
+	const navigate = useNavigate();
 	const { collection: allNotices } = useNotices();
 	const [currentPage, setCurrentPage] = useState(1);
 	const noticesPerPage = 5;
@@ -108,6 +109,13 @@ function RouteComponent() {
 												isArchived={notice.isArchived}
 												isPublished={notice.isPublished}
 												noticeDate={notice.noticeDate}
+												onNoticeClick={() =>
+													navigate({
+														params: { noticeId: notice.id },
+														to: "/notices/$noticeId",
+													})
+												}
+												showShare={false}
 												title={notice.title}
 												type={notice.noticeType}
 											/>

--- a/apps/notices/src/routes/(app)/notices/$noticeId.tsx
+++ b/apps/notices/src/routes/(app)/notices/$noticeId.tsx
@@ -1,4 +1,7 @@
+import { formatDate } from "@mcmec/lib/functions/date-fns";
+import { PublicNoticeBadge } from "@mcmec/ui/blocks/public-notice-badge";
 import { PublicNoticeCard } from "@mcmec/ui/blocks/public-notice-card";
+import { TiptapRenderer } from "@mcmec/ui/blocks/tiptap-renderer";
 import { Button } from "@mcmec/ui/components/button";
 import {
 	createFileRoute,
@@ -85,14 +88,19 @@ function RouteComponent() {
 				</div>
 			</nav>
 
-			<PublicNoticeCard
-				content={content}
-				isArchived={is_archived}
-				isPublished={is_published}
-				noticeDate={notice_date || new Date()}
-				title={title}
-				type={type || "General"}
-			/>
+			<article className="prose">
+				<div className="flex flex-row items-baseline gap-2">
+					<h2>{title}</h2>
+					<PublicNoticeBadge
+						isArchived={is_archived}
+						isPublished={is_published}
+						noticeDate={notice_date}
+					/>
+				</div>
+				<h4>Type: {type}</h4>
+				<h4>Published on: {formatDate(notice_date)}</h4>
+				<TiptapRenderer content={content} />
+			</article>
 		</div>
 	);
 }

--- a/apps/public/src/routeTree.gen.ts
+++ b/apps/public/src/routeTree.gen.ts
@@ -9,18 +9,19 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
-import { Route as NoticesRouteImport } from './routes/notices'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as NoticesIndexRouteImport } from './routes/notices/index'
 import { Route as ArchiveIndexRouteImport } from './routes/archive/index'
+import { Route as NoticesNoticeIdRouteImport } from './routes/notices/$noticeId'
 
-const NoticesRoute = NoticesRouteImport.update({
-  id: '/notices',
-  path: '/notices',
-  getParentRoute: () => rootRouteImport,
-} as any)
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const NoticesIndexRoute = NoticesIndexRouteImport.update({
+  id: '/notices/',
+  path: '/notices/',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ArchiveIndexRoute = ArchiveIndexRouteImport.update({
@@ -28,51 +29,60 @@ const ArchiveIndexRoute = ArchiveIndexRouteImport.update({
   path: '/archive/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const NoticesNoticeIdRoute = NoticesNoticeIdRouteImport.update({
+  id: '/notices/$noticeId',
+  path: '/notices/$noticeId',
+  getParentRoute: () => rootRouteImport,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
-  '/notices': typeof NoticesRoute
+  '/notices/$noticeId': typeof NoticesNoticeIdRoute
   '/archive': typeof ArchiveIndexRoute
+  '/notices': typeof NoticesIndexRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
-  '/notices': typeof NoticesRoute
+  '/notices/$noticeId': typeof NoticesNoticeIdRoute
   '/archive': typeof ArchiveIndexRoute
+  '/notices': typeof NoticesIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
-  '/notices': typeof NoticesRoute
+  '/notices/$noticeId': typeof NoticesNoticeIdRoute
   '/archive/': typeof ArchiveIndexRoute
+  '/notices/': typeof NoticesIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/notices' | '/archive'
+  fullPaths: '/' | '/notices/$noticeId' | '/archive' | '/notices'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/notices' | '/archive'
-  id: '__root__' | '/' | '/notices' | '/archive/'
+  to: '/' | '/notices/$noticeId' | '/archive' | '/notices'
+  id: '__root__' | '/' | '/notices/$noticeId' | '/archive/' | '/notices/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
-  NoticesRoute: typeof NoticesRoute
+  NoticesNoticeIdRoute: typeof NoticesNoticeIdRoute
   ArchiveIndexRoute: typeof ArchiveIndexRoute
+  NoticesIndexRoute: typeof NoticesIndexRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    '/notices': {
-      id: '/notices'
-      path: '/notices'
-      fullPath: '/notices'
-      preLoaderRoute: typeof NoticesRouteImport
-      parentRoute: typeof rootRouteImport
-    }
     '/': {
       id: '/'
       path: '/'
       fullPath: '/'
       preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/notices/': {
+      id: '/notices/'
+      path: '/notices'
+      fullPath: '/notices'
+      preLoaderRoute: typeof NoticesIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/archive/': {
@@ -82,13 +92,21 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ArchiveIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/notices/$noticeId': {
+      id: '/notices/$noticeId'
+      path: '/notices/$noticeId'
+      fullPath: '/notices/$noticeId'
+      preLoaderRoute: typeof NoticesNoticeIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
-  NoticesRoute: NoticesRoute,
+  NoticesNoticeIdRoute: NoticesNoticeIdRoute,
   ArchiveIndexRoute: ArchiveIndexRoute,
+  NoticesIndexRoute: NoticesIndexRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/apps/public/src/routes/__root.tsx
+++ b/apps/public/src/routes/__root.tsx
@@ -16,7 +16,7 @@ const RootLayout = () => (
 		<Header />
 		<Navbar />
 
-		<main className="flex-1 p-4">
+		<main className="max-w-7xl flex-1 p-4">
 			<Outlet />
 		</main>
 		<Footer />

--- a/apps/public/src/routes/notices/$noticeId.tsx
+++ b/apps/public/src/routes/notices/$noticeId.tsx
@@ -1,0 +1,73 @@
+import {
+	formatDate,
+	formatDateShort,
+	formatTime,
+} from "@mcmec/lib/functions/date-fns";
+import { PublicNoticeBadge } from "@mcmec/ui/blocks/public-notice-badge";
+import { TiptapRenderer } from "@mcmec/ui/blocks/tiptap-renderer";
+import { Button } from "@mcmec/ui/components/button";
+import { Label } from "@mcmec/ui/components/label";
+import { createFileRoute, Link, notFound } from "@tanstack/react-router";
+import { ChevronLeft } from "lucide-react";
+import { notice_types } from "@/src/lib/collections/notice_types";
+import { notices } from "@/src/lib/collections/notices";
+export const Route = createFileRoute("/notices/$noticeId")({
+	component: RouteComponent,
+	loader: async ({ params }) => {
+		await Promise.all([notices.preload(), notice_types.preload()]);
+		const notice = notices.get(params.noticeId);
+		if (!notice) {
+			throw notFound();
+		}
+		return { notice };
+	},
+});
+
+function RouteComponent() {
+	const { notice } = Route.useLoaderData();
+	const {
+		id,
+		title,
+		notice_type_id,
+		notice_date,
+		content,
+		is_published,
+		is_archived,
+		updated_at,
+	} = notice;
+
+	const type = notice_types.get(notice_type_id)?.name;
+
+	return (
+		<>
+			<Button asChild variant="link">
+				<Link to={`/notices`}>
+					<ChevronLeft />
+					Return to Current Notices
+				</Link>
+			</Button>
+
+			<article className="prose">
+				<h2>{title}</h2>
+				<div className="flex flex-row items-center gap-2">
+					<Label>Status: </Label>
+					<PublicNoticeBadge
+						isArchived={is_archived}
+						isPublished={is_published}
+						noticeDate={notice_date}
+					/>
+				</div>
+
+				<h3>Notice Date: {formatDate(notice_date)}</h3>
+				<TiptapRenderer content={content} />
+			</article>
+			<div className="flex flex-col text-muted text-sm italic">
+				<p>Notice Type: {type}</p>
+				<p>Notice ID: {id}</p>
+				<p>
+					Last updated: {formatDateShort(updated_at)} {formatTime(updated_at)}
+				</p>
+			</div>
+		</>
+	);
+}

--- a/apps/public/src/routes/notices/index.tsx
+++ b/apps/public/src/routes/notices/index.tsx
@@ -1,10 +1,10 @@
 import { PublicNoticeCard } from "@mcmec/ui/blocks/public-notice-card";
 import { eq, useLiveQuery } from "@tanstack/react-db";
-import { createFileRoute } from "@tanstack/react-router";
-import { notice_types } from "../lib/collections/notice_types";
-import { notices } from "../lib/collections/notices";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { notice_types } from "../../lib/collections/notice_types";
+import { notices } from "../../lib/collections/notices";
 
-export const Route = createFileRoute("/notices")({
+export const Route = createFileRoute("/notices/")({
 	component: RouteComponent,
 	loader: async () => {
 		await Promise.all([notices.preload(), notice_types.preload()]);
@@ -12,6 +12,7 @@ export const Route = createFileRoute("/notices")({
 });
 
 function RouteComponent() {
+	const navigate = useNavigate();
 	const { data: noticesToShow } = useLiveQuery((q) =>
 		q
 			.from({ notice: notices })
@@ -36,17 +37,27 @@ function RouteComponent() {
 			<h3 className="w-full text-center font-bold text-2xl">
 				Current Legal Notices
 			</h3>
-			{noticesToShow?.map((notice) => (
-				<PublicNoticeCard
-					content={notice.content}
-					isArchived={notice.isArchived}
-					isPublished={notice.isPublished}
-					key={notice.id}
-					noticeDate={notice.noticeDate}
-					title={notice.title}
-					type={notice.type}
-				/>
-			))}
+			{noticesToShow?.map((notice) => {
+				const shareUrl = `${window.location.origin}/notices/${notice.id}`;
+				return (
+					<PublicNoticeCard
+						content={notice.content}
+						getShareUrl={() => shareUrl}
+						isArchived={notice.isArchived}
+						isPublished={notice.isPublished}
+						key={notice.id}
+						noticeDate={notice.noticeDate}
+						onNoticeClick={() =>
+							navigate({
+								params: { noticeId: notice.id },
+								to: "/notices/$noticeId",
+							})
+						}
+						title={notice.title}
+						type={notice.type}
+					/>
+				);
+			})}
 		</div>
 	);
 }

--- a/packages/ui/src/blocks/public-notice-badge.tsx
+++ b/packages/ui/src/blocks/public-notice-badge.tsx
@@ -1,0 +1,39 @@
+import { Badge } from "../components/badge";
+
+interface PublicNoticeBadgeProps {
+	isPublished: boolean;
+	isArchived: boolean;
+	noticeDate: Date;
+}
+
+export function PublicNoticeBadge({
+	isPublished,
+	isArchived,
+	noticeDate,
+}: PublicNoticeBadgeProps) {
+	const now = new Date();
+	const isPending = noticeDate > now;
+	const status = isPublished
+		? isArchived
+			? "Archived"
+			: isPending
+				? "Pending"
+				: "Published"
+		: "Draft";
+
+	return (
+		<Badge
+			variant={
+				status === "Published"
+					? "default"
+					: status === "Pending"
+						? "default"
+						: status === "Archived"
+							? "secondary"
+							: "outline"
+			}
+		>
+			{status}
+		</Badge>
+	);
+}


### PR DESCRIPTION
Transform the public notice card into a preview card that includes navigation to the notice page and sharing capabilities. Introduce a new route for displaying notices and enhance the design of the notice route in the notice manager.