### PR TITLE
chore: remove unused Caddyfile

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,8 +1,0 @@
-# Caddyfile
-http://central.local.test:8080 {
-    reverse_proxy localhost:3001
-}
-
-http://login.local.test:8080 {
-    reverse_proxy localhost:3000
-}


### PR DESCRIPTION
## Summary
- Removes the dead `Caddyfile` that was used for local reverse proxy but is no longer needed
- All apps run directly on their dev server ports and deploy to Vercel

## Test plan
- [x] No runtime impact — file was not referenced anywhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)