### PR TITLE
fix: include dist/ in Turbo build outputs

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -11,7 +11,7 @@
 				"CLOUDFLARE_TURNSTILE_SECRETKEY"
 			],
 			"inputs": ["$TURBO_DEFAULT$", ".env*"],
-			"outputs": [".output/**"]
+			"outputs": ["dist/**", ".output/**"]
 		},
 		"check-types": {
 			"dependsOn": ["^check-types"]


### PR DESCRIPTION
## Summary
- Adds `dist/**` to Turbo build task outputs alongside `.output/**`
- `central` and `notices` apps output to `dist/`, but only `.output/**` was listed — Turbo caching was silently broken for those two apps

## Test plan
- [ ] Run `pnpm turbo run build --filter=central` twice — second run should be cached
- [ ] Run `pnpm turbo run build --filter=public` twice — second run should still be cached

🤖 Generated with [Claude Code](https://claude.com/claude-code)