### PR TITLE
ci: add GitHub Actions workflow for PR checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,58 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  ci:
+    name: Lint, Types & Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Lint (Biome)
+        run: pnpm lint
+
+      - name: Type check
+        run: pnpm check-types
+
+      - name: Build all apps
+        run: pnpm build
+        env:
+          VITE_SUPABASE_URL: http://localhost:54321
+          VITE_SUPABASE_PUBLISHABLE_KEY: placeholder
+          VITE_CLOUDFLARE_TURNSTILE_SITEKEY: placeholder
+          SUPABASE_SERVICE_ROLE_KEY: placeholder
+          CLOUDFLARE_TURNSTILE_SECRETKEY: placeholder
+
+  test:
+    name: Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Run tests
+        run: pnpm --filter @mcmec/supabase test:run


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci.yml` that runs on every PR to `main`
- **Lint job**: Biome lint, type checking, and full build (all apps)
- **Test job**: Runs supabase package unit tests
- Concurrency control cancels stale runs when new commits are pushed
- Placeholder env vars used for build step (no secrets needed for CI builds)

## Test plan
- [ ] Merge this PR and open a test PR — CI should trigger automatically
- [ ] Verify lint, type check, build, and test steps all pass
- [ ] Once confirmed, enable "Require status checks to pass" in branch protection for `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)