### PR TITLE
chore: remove useSortedKeys Biome rule

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -4,8 +4,7 @@
 		"actions": {
 			"source": {
 				"organizeImports": "on",
-				"useSortedAttributes": "on",
-				"useSortedKeys": "on"
+				"useSortedAttributes": "on"
 			}
 		},
 		"enabled": true


### PR DESCRIPTION
## Summary
- Removes the `useSortedKeys` assist action from Biome config
- This rule added noise and flagged false positives on files where key order is intentional or conventional (e.g., `package.json`, `vercel.json`)
- `organizeImports` and `useSortedAttributes` are retained

## Test plan
- [ ] Run `pnpm lint` — should pass without sorted key warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)