### PR TITLE
chore: add PR review workflow tooling

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,32 @@
+"app:central":
+  - changed-files:
+      - any-glob-to-any-file: "apps/central/**"
+
+"app:notices":
+  - changed-files:
+      - any-glob-to-any-file: "apps/notices/**"
+
+"app:public":
+  - changed-files:
+      - any-glob-to-any-file: "apps/public/**"
+
+"packages":
+  - changed-files:
+      - any-glob-to-any-file: "packages/**"
+
+"migration":
+  - changed-files:
+      - any-glob-to-any-file: "supabase/migrations/**"
+
+"ci":
+  - changed-files:
+      - any-glob-to-any-file: ".github/workflows/**"
+
+"config":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "package.json"
+          - "pnpm-lock.yaml"
+          - "turbo.json"
+          - "biome.json"
+          - "tsconfig*.json"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+## Summary
+<!-- What changed and why? -->
+
+
+## Checklist
+- [ ] Tested locally (`pnpm dev` / `supabase db reset` if migrations changed)
+- [ ] Types pass (`pnpm check-types`)
+- [ ] Changeset added (`pnpm change`) — or N/A for config/CI-only changes
+- [ ] No new env vars without updating `.env.example`
+- [ ] No secrets committed
+
+### If this PR includes Supabase migrations:
+> **Warning:** Migrations auto-apply to the production database when merged to `main`.
+
+- [ ] Migration tested locally with `supabase db reset`
+- [ ] Migration is backwards-compatible (no destructive column/table drops without coordination)

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -1,0 +1,26 @@
+name: Changeset Check
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  changeset:
+    name: Check for changeset
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Check changeset status
+        run: pnpm changeset status --since=origin/main

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,17 @@
+name: Label PRs
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          configuration-path: .github/labeler.yml


### PR DESCRIPTION
## Summary
- **PR template** with checklist: local testing, types, changesets, env vars, secrets, and a migration safety warning
- **Auto-labeler** tags PRs by area: `app:central`, `app:notices`, `app:public`, `packages`, `migration`, `ci`, `config`
- **Changeset check** runs `changeset status` on PRs — warns if missing but does not block merge (configure as non-required status check)

## Test plan
- [ ] Open a test PR — body should pre-fill with the template checklist
- [ ] PR touching `apps/central/` should get `app:central` label
- [ ] PR touching `supabase/migrations/` should get `migration` label
- [ ] PR without a changeset should show changeset check as failing (non-blocking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)