### PR TITLE
feat: add create-account edge function

### DIFF
--- a/supabase/functions/create-account/index.ts
+++ b/supabase/functions/create-account/index.ts
@@ -1,0 +1,115 @@
+import { createClient } from "jsr:@supabase/supabase-js@2";
+
+const corsHeaders = {
+	"Access-Control-Allow-Headers":
+		"authorization, x-client-info, apikey, content-type",
+	"Access-Control-Allow-Methods": "POST, OPTIONS",
+	"Access-Control-Allow-Origin": "*",
+};
+
+Deno.serve(async (req) => {
+	// Handle CORS preflight
+	if (req.method === "OPTIONS") {
+		return new Response(null, { headers: corsHeaders, status: 204 });
+	}
+
+	if (req.method !== "POST") {
+		return Response.json(
+			{ error: "Method not allowed" },
+			{ headers: corsHeaders, status: 405 },
+		);
+	}
+
+	try {
+		const { email, password } = await req.json();
+
+		// Validate input
+		if (!email || typeof email !== "string") {
+			return Response.json(
+				{ error: "Email is required." },
+				{ headers: corsHeaders, status: 400 },
+			);
+		}
+
+		if (!password || typeof password !== "string" || password.length < 6) {
+			return Response.json(
+				{ error: "Password must be at least 6 characters." },
+				{ headers: corsHeaders, status: 400 },
+			);
+		}
+
+		// Create admin client with service role key
+		const supabaseAdmin = createClient(
+			Deno.env.get("SUPABASE_URL")!,
+			Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
+		);
+
+		// Check if employee exists with this email
+		const { data: employee, error: employeeError } = await supabaseAdmin
+			.from("employees")
+			.select("id, user_id")
+			.eq("email", email.toLowerCase().trim())
+			.maybeSingle();
+
+		if (employeeError) {
+			return Response.json(
+				{ error: "Unable to verify employee record." },
+				{ headers: corsHeaders, status: 500 },
+			);
+		}
+
+		if (!employee) {
+			return Response.json(
+				{ error: "No employee record found for this email." },
+				{ headers: corsHeaders, status: 400 },
+			);
+		}
+
+		if (employee.user_id) {
+			return Response.json(
+				{ error: "An account already exists for this email." },
+				{ headers: corsHeaders, status: 400 },
+			);
+		}
+
+		// Create auth user
+		const { data: newUser, error: createError } =
+			await supabaseAdmin.auth.admin.createUser({
+				email: email.toLowerCase().trim(),
+				email_confirm: true,
+				password,
+			});
+
+		if (createError || !newUser.user) {
+			return Response.json(
+				{ error: createError?.message ?? "Unable to create account." },
+				{ headers: corsHeaders, status: 500 },
+			);
+		}
+
+		// Link employee to the new auth user
+		const { error: linkError } = await supabaseAdmin
+			.from("employees")
+			.update({ user_id: newUser.user.id })
+			.eq("id", employee.id);
+
+		if (linkError) {
+			// Attempt to clean up the created user
+			await supabaseAdmin.auth.admin.deleteUser(newUser.user.id);
+			return Response.json(
+				{ error: "Account created but failed to link employee record." },
+				{ headers: corsHeaders, status: 500 },
+			);
+		}
+
+		return Response.json(
+			{ success: true },
+			{ headers: corsHeaders, status: 200 },
+		);
+	} catch {
+		return Response.json(
+			{ error: "An unexpected error occurred." },
+			{ headers: corsHeaders, status: 500 },
+		);
+	}
+});

--- a/supabase/functions/tests/create-account.test.ts
+++ b/supabase/functions/tests/create-account.test.ts
@@ -1,0 +1,116 @@
+import {
+	assert,
+	assertEquals,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL") ?? "http://127.0.0.1:54321";
+const ANON_KEY = Deno.env.get("SUPABASE_ANON_KEY") ?? "";
+const SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "";
+
+const FUNCTION_URL = `${SUPABASE_URL}/functions/v1/create-account`;
+
+async function callFunction(body: Record<string, unknown>): Promise<Response> {
+	return fetch(FUNCTION_URL, {
+		body: JSON.stringify(body),
+		headers: {
+			Authorization: `Bearer ${ANON_KEY}`,
+			"Content-Type": "application/json",
+		},
+		method: "POST",
+	});
+}
+
+async function deleteTestUser(email: string): Promise<void> {
+	const { createClient } = await import("jsr:@supabase/supabase-js@2");
+	const admin = createClient(SUPABASE_URL, SERVICE_ROLE_KEY);
+
+	// Find and delete auth user by email
+	const { data } = await admin.auth.admin.listUsers();
+	const user = data?.users?.find((u) => u.email === email);
+	if (user) {
+		await admin.auth.admin.deleteUser(user.id);
+	}
+
+	// Unlink employee
+	await admin.from("employees").update({ user_id: null }).eq("email", email);
+}
+
+Deno.test("should reject missing email", async () => {
+	const res = await callFunction({ password: "password123" });
+	assertEquals(res.status, 400);
+	const body = await res.json();
+	assertEquals(body.error, "Email is required.");
+});
+
+Deno.test("should reject missing password", async () => {
+	const res = await callFunction({ email: "test@test.local" });
+	assertEquals(res.status, 400);
+	const body = await res.json();
+	assertEquals(body.error, "Password must be at least 6 characters.");
+});
+
+Deno.test("should reject short password", async () => {
+	const res = await callFunction({
+		email: "test@test.local",
+		password: "short",
+	});
+	assertEquals(res.status, 400);
+	const body = await res.json();
+	assertEquals(body.error, "Password must be at least 6 characters.");
+});
+
+Deno.test("should reject email not in employees table", async () => {
+	const res = await callFunction({
+		email: "nonexistent@test.local",
+		password: "password123",
+	});
+	assertEquals(res.status, 400);
+	const body = await res.json();
+	assertEquals(body.error, "No employee record found for this email.");
+});
+
+Deno.test("should reject email that already has an account", async () => {
+	// admin@test.local is seeded with a linked user_id
+	const res = await callFunction({
+		email: "admin@test.local",
+		password: "password123",
+	});
+	assertEquals(res.status, 400);
+	const body = await res.json();
+	assertEquals(body.error, "An account already exists for this email.");
+});
+
+Deno.test("should create account for unlinked employee", async () => {
+	// unlinked@test.local is seeded without a user_id
+	const res = await callFunction({
+		email: "unlinked@test.local",
+		password: "password123",
+	});
+	assertEquals(res.status, 200);
+	const body = await res.json();
+	assert(body.success);
+
+	// Clean up: delete the created user and unlink employee
+	await deleteTestUser("unlinked@test.local");
+});
+
+Deno.test("should reject second account creation for same employee", async () => {
+	// Create account first
+	const res1 = await callFunction({
+		email: "unlinked@test.local",
+		password: "password123",
+	});
+	assertEquals(res1.status, 200);
+
+	// Try again — should fail
+	const res2 = await callFunction({
+		email: "unlinked@test.local",
+		password: "password123",
+	});
+	assertEquals(res2.status, 400);
+	const body = await res2.json();
+	assertEquals(body.error, "An account already exists for this email.");
+
+	// Clean up
+	await deleteTestUser("unlinked@test.local");
+});


### PR DESCRIPTION
## Summary
- New Supabase Edge Function at `supabase/functions/create-account/`
- Handles employee self-service account creation:
  1. Validates email + password (min 6 chars)
  2. Verifies email exists in employees table
  3. Rejects if no match or already linked to an account
  4. Creates auth user via `admin.createUser()` (no email confirmation needed)
  5. Links employee row by setting `user_id`
  6. Rolls back auth user if employee linking fails
- Includes Deno test file with 7 test scenarios

Closes part of #45

## Test plan
- [x] All 7 test scenarios verified manually against local Supabase:
  - Missing email → 400
  - Missing/short password → 400
  - Email not in employees → 400
  - Already linked employee → 400
  - Successful creation → 200
  - Duplicate creation attempt → 400
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)