### PR TITLE
chore: version packages from changesets

### DIFF
--- a/.changeset/auth-invite-flow.md
+++ b/.changeset/auth-invite-flow.md
@@ -1,6 +1,0 @@
----
-"central": minor
-"notices": patch
----
-
-Rework auth flow to use email-based invites via Resend SMTP. Replace create-account edge function with invite-employee. Add set-password, forgot-password, and reset-password pages to central. Update both apps to use @mcmec/auth package with typed errors.

--- a/.changeset/auth-package.md
+++ b/.changeset/auth-package.md
@@ -1,6 +1,0 @@
----
-"@mcmec/auth": minor
-"@mcmec/lib": patch
----
-
-New @mcmec/auth package with typed errors, canonical Claims type, and dependency injection pattern. Update PasswordSchema minimum from 8 to 6 characters.

--- a/.changeset/employees-table.md
+++ b/.changeset/employees-table.md
@@ -1,6 +1,0 @@
----
-"@mcmec/supabase": minor
-"notices": patch
----
-
-Replace user_profiles table with employees table. Employees table tracks all agency staff with optional auth user linkage. Rename profiles collection/accessor to employees across supabase package and notices app. Remove avatar_url field. Regenerated database types.

--- a/.changeset/quick-dancers-visit.md
+++ b/.changeset/quick-dancers-visit.md
@@ -1,5 +1,0 @@
----
-"public": patch
----
-
-Turnstile hotfix.

--- a/.changeset/remove-old-auth.md
+++ b/.changeset/remove-old-auth.md
@@ -1,5 +1,0 @@
----
-"@mcmec/supabase": minor
----
-
-Remove old auth functions (claims, session, signIn, signOut) from @mcmec/supabase. Auth is now handled by the dedicated @mcmec/auth package.

--- a/.changeset/salty-drinks-relax.md
+++ b/.changeset/salty-drinks-relax.md
@@ -1,6 +1,0 @@
----
-"central": patch
-"notices": patch
----
-
-Hotfix for explicit build output directory on Vercel configuration.

--- a/.changeset/tender-teeth-lay.md
+++ b/.changeset/tender-teeth-lay.md
@@ -1,5 +1,0 @@
----
-"public": patch
----
-
-Hotfix for broken link on home page to public meetings page.

--- a/apps/central/CHANGELOG.md
+++ b/apps/central/CHANGELOG.md
@@ -1,5 +1,22 @@
 # central
 
+## 0.2.0
+
+### Minor Changes
+
+- 2cea2d6: Rework auth flow to use email-based invites via Resend SMTP. Replace create-account edge function with invite-employee. Add set-password, forgot-password, and reset-password pages to central. Update both apps to use @mcmec/auth package with typed errors.
+
+### Patch Changes
+
+- dcf90f1: Hotfix for explicit build output directory on Vercel configuration.
+- Updated dependencies [a8b88f5]
+- Updated dependencies [2affcd1]
+- Updated dependencies [184752c]
+  - @mcmec/auth@0.2.0
+  - @mcmec/lib@0.7.1
+  - @mcmec/supabase@1.3.0
+  - @mcmec/ui@1.4.1
+
 ## 0.1.7
 
 ### Patch Changes

--- a/apps/central/package.json
+++ b/apps/central/package.json
@@ -42,5 +42,5 @@
 		"sync-assets": "shx mkdir -p public/shared && shx cp -r ../../packages/assets/images/* public/shared/"
 	},
 	"type": "module",
-	"version": "0.1.7"
+	"version": "0.2.0"
 }

--- a/apps/notices/CHANGELOG.md
+++ b/apps/notices/CHANGELOG.md
@@ -1,5 +1,20 @@
 # notices
 
+## 0.7.2
+
+### Patch Changes
+
+- 2cea2d6: Rework auth flow to use email-based invites via Resend SMTP. Replace create-account edge function with invite-employee. Add set-password, forgot-password, and reset-password pages to central. Update both apps to use @mcmec/auth package with typed errors.
+- 2affcd1: Replace user_profiles table with employees table. Employees table tracks all agency staff with optional auth user linkage. Rename profiles collection/accessor to employees across supabase package and notices app. Remove avatar_url field. Regenerated database types.
+- dcf90f1: Hotfix for explicit build output directory on Vercel configuration.
+- Updated dependencies [a8b88f5]
+- Updated dependencies [2affcd1]
+- Updated dependencies [184752c]
+  - @mcmec/auth@0.2.0
+  - @mcmec/lib@0.7.1
+  - @mcmec/supabase@1.3.0
+  - @mcmec/ui@1.4.1
+
 ## 0.7.1
 
 ### Patch Changes

--- a/apps/notices/package.json
+++ b/apps/notices/package.json
@@ -47,5 +47,5 @@
 		"sync-assets": "shx mkdir -p public/shared && shx cp -r ../../packages/assets/images/* public/shared/"
 	},
 	"type": "module",
-	"version": "0.7.1"
+	"version": "0.7.2"
 }

--- a/apps/public/CHANGELOG.md
+++ b/apps/public/CHANGELOG.md
@@ -1,5 +1,18 @@
 # public
 
+## 1.1.1
+
+### Patch Changes
+
+- 062f055: Turnstile hotfix.
+- 5fbfb4f: Hotfix for broken link on home page to public meetings page.
+- Updated dependencies [a8b88f5]
+- Updated dependencies [2affcd1]
+- Updated dependencies [184752c]
+  - @mcmec/lib@0.7.1
+  - @mcmec/supabase@1.3.0
+  - @mcmec/ui@1.4.1
+
 ## 1.1.0
 
 ### Minor Changes

--- a/apps/public/package.json
+++ b/apps/public/package.json
@@ -54,5 +54,5 @@
 		"sync-assets": "shx mkdir -p public && shx cp -r ../../packages/assets/images/* public/"
 	},
 	"type": "module",
-	"version": "1.1.0"
+	"version": "1.1.1"
 }

--- a/packages/auth/CHANGELOG.md
+++ b/packages/auth/CHANGELOG.md
@@ -1,0 +1,12 @@
+# @mcmec/auth
+
+## 0.2.0
+
+### Minor Changes
+
+- a8b88f5: New @mcmec/auth package with typed errors, canonical Claims type, and dependency injection pattern. Update PasswordSchema minimum from 8 to 6 characters.
+
+### Patch Changes
+
+- Updated dependencies [a8b88f5]
+  - @mcmec/lib@0.7.1

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@mcmec/auth",
-	"version": "0.1.0",
+	"version": "0.2.0",
 	"type": "module",
 	"exports": {
 		"./verifyClaims": "./src/verifyClaims.ts",

--- a/packages/lib/CHANGELOG.md
+++ b/packages/lib/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @mcmec/lib
 
+## 0.7.1
+
+### Patch Changes
+
+- a8b88f5: New @mcmec/auth package with typed errors, canonical Claims type, and dependency injection pattern. Update PasswordSchema minimum from 8 to 6 characters.
+
 ## 0.7.0
 
 ### Minor Changes

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -29,5 +29,5 @@
 		"lint": "biome check --write ."
 	},
 	"type": "module",
-	"version": "0.7.0"
+	"version": "0.7.1"
 }

--- a/packages/supabase/CHANGELOG.md
+++ b/packages/supabase/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @mcmec/supabase
 
+## 1.3.0
+
+### Minor Changes
+
+- 2affcd1: Replace user_profiles table with employees table. Employees table tracks all agency staff with optional auth user linkage. Rename profiles collection/accessor to employees across supabase package and notices app. Remove avatar_url field. Regenerated database types.
+- 184752c: Remove old auth functions (claims, session, signIn, signOut) from @mcmec/supabase. Auth is now handled by the dedicated @mcmec/auth package.
+
+### Patch Changes
+
+- Updated dependencies [a8b88f5]
+  - @mcmec/lib@0.7.1
+
 ## 1.2.0
 
 ### Minor Changes

--- a/packages/supabase/package.json
+++ b/packages/supabase/package.json
@@ -30,5 +30,5 @@
 		"test:run": "vitest run"
 	},
 	"type": "module",
-	"version": "1.2.0"
+	"version": "1.3.0"
 }

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @mcmec/ui
 
+## 1.4.1
+
+### Patch Changes
+
+- Updated dependencies [a8b88f5]
+  - @mcmec/lib@0.7.1
+
 ## 1.4.0
 
 ### Minor Changes

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -91,5 +91,5 @@
 		"lint": "biome check --write ."
 	},
 	"type": "module",
-	"version": "1.4.0"
+	"version": "1.4.1"
 }


### PR DESCRIPTION
## Summary
Consumes all pending changesets and bumps package versions:

- `@mcmec/auth`: 0.1.0 → 0.2.0 (new package + employeeId changes)
- `@mcmec/lib`: patch bump (password min change)
- `@mcmec/supabase`: minor bump (employees table, removed old auth)
- `central`: minor bump (auth flows, new pages)
- `notices`: patch bump (route guard updates)
- `public`: patch bump (Turnstile hotfix from earlier)
- `@mcmec/ui`: patch bump

Merge this before the develop → main promotion PR (#52).

🤖 Generated with [Claude Code](https://claude.com/claude-code)