### PR TITLE
fix: update supabase CLI version in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
 
       - uses: supabase/setup-cli@v1
         with:
-          version: 1.187.8
+          version: 2.75.0
 
       - name: Start Supabase
         run: supabase start


### PR DESCRIPTION
## Summary
The pinned Supabase CLI version (1.187.8) is too old for our config.toml — it doesn't recognize newer fields like `db.migrations`, `auth.rate_limit`, etc. Update to v2.75.0 which matches the locally installed version.

## Test plan
- [ ] CI passes
- [ ] Integration tests can start Supabase in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)