### PR TITLE
fix: seed data in CI for integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,8 +75,8 @@ jobs:
         with:
           version: 2.75.0
 
-      - name: Start Supabase
-        run: supabase start
+      - name: Start Supabase and seed data
+        run: supabase start && supabase db reset
 
       - name: Get Supabase keys
         id: supabase-keys


### PR DESCRIPTION
## Summary
`supabase start` applies migrations but doesn't run seeds. Integration tests need the seed user (`admin@test.local`) to sign in. Add `supabase db reset` after start to seed the database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)