### PR TITLE
release: email templates + invite redirect fix

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -145,7 +145,7 @@ max_indexes = 5
 enabled = true
 # The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
 # in emails.
-site_url = "http://127.0.0.1:3000"
+site_url = "http://localhost:3001"
 # A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
 additional_redirect_urls = ["https://127.0.0.1:3000", "http://localhost:3001"]
 # How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
@@ -220,16 +220,13 @@ otp_expiry = 3600
 # admin_email = "admin@email.com"
 # sender_name = "Admin"
 
-# Uncomment to customize email template
-# [auth.email.template.invite]
-# subject = "You have been invited"
-# content_path = "./supabase/templates/invite.html"
+[auth.email.template.invite]
+subject = "You've been invited to MCMEC Central"
+content_path = "./supabase/templates/invite.html"
 
-# Uncomment to customize notification email template
-# [auth.email.notification.password_changed]
-# enabled = true
-# subject = "Your password has been changed"
-# content_path = "./templates/password_changed_notification.html"
+[auth.email.template.recovery]
+subject = "Reset your MCMEC password"
+content_path = "./supabase/templates/reset-password.html"
 
 [auth.sms]
 # Allow/disallow new user signups via SMS to your project.

--- a/supabase/functions/invite-employee/index.ts
+++ b/supabase/functions/invite-employee/index.ts
@@ -71,7 +71,9 @@ Deno.serve(async (req) => {
 		// Creates the auth user and sends a magic link email via Resend SMTP
 		// Employee clicks the link → lands on central's /set-password page
 		const { data: inviteData, error: inviteError } =
-			await supabaseAdmin.auth.admin.inviteUserByEmail(normalizedEmail);
+			await supabaseAdmin.auth.admin.inviteUserByEmail(normalizedEmail, {
+				redirectTo: `${Deno.env.get("SUPABASE_URL")?.replace("127.0.0.1:54321", "localhost:3001")}/set-password`,
+			});
 
 		if (inviteError || !inviteData.user) {
 			return Response.json(

--- a/supabase/templates/invite.html
+++ b/supabase/templates/invite.html
@@ -1,0 +1,10 @@
+<html>
+<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 600px; margin: 0 auto; padding: 40px 20px; color: #1a1a1a;">
+  <h2 style="margin-bottom: 8px;">Welcome to MCMEC Central</h2>
+  <p style="color: #555; margin-bottom: 24px;">You've been invited to create your account for the Middlesex County Mosquito Extermination Commission portal.</p>
+  <p style="margin-bottom: 24px;">
+    <a href="{{ .ConfirmationURL }}%2Fset-password" style="display: inline-block; background-color: #1a1a1a; color: #ffffff; padding: 12px 24px; text-decoration: none; border-radius: 6px; font-weight: 500;">Set Your Password</a>
+  </p>
+  <p style="color: #888; font-size: 14px;">If you didn't expect this invitation, you can safely ignore this email.</p>
+</body>
+</html>

--- a/supabase/templates/reset-password.html
+++ b/supabase/templates/reset-password.html
@@ -1,0 +1,10 @@
+<html>
+<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 600px; margin: 0 auto; padding: 40px 20px; color: #1a1a1a;">
+  <h2 style="margin-bottom: 8px;">Reset Your Password</h2>
+  <p style="color: #555; margin-bottom: 24px;">We received a request to reset your password for MCMEC Central.</p>
+  <p style="margin-bottom: 24px;">
+    <a href="{{ .ConfirmationURL }}" style="display: inline-block; background-color: #1a1a1a; color: #ffffff; padding: 12px 24px; text-decoration: none; border-radius: 6px; font-weight: 500;">Reset Password</a>
+  </p>
+  <p style="color: #888; font-size: 14px;">If you didn't request this, you can safely ignore this email. Your password will not change.</p>
+</body>
+</html>


### PR DESCRIPTION
## Release

Ships email templates and invite flow fixes.

### Changes (4 files)
- `supabase/templates/invite.html` — invite email template
- `supabase/templates/reset-password.html` — password reset email template
- `supabase/config.toml` — template config + site_url update for local dev
- `supabase/functions/invite-employee/index.ts` — add redirectTo for /set-password

### Post-deploy
- [ ] Copy invite template to Supabase dashboard
- [ ] Copy reset password template to Supabase dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)