### PR TITLE
feat: add mosquito spray schedule

### DIFF
--- a/.changeset/spray-schedule.md
+++ b/.changeset/spray-schedule.md
@@ -1,0 +1,8 @@
+---
+"notices": minor
+"public": minor
+"@mcmec/supabase": minor
+"@mcmec/ui": minor
+---
+
+Add mosquito spray schedule feature with admin CRUD in notices app, public display with filters at /spray-schedule, new TimeField and MultiComboboxField UI components, and dashboard integration.

--- a/apps/notices/src/components/notices-sidebar.tsx
+++ b/apps/notices/src/components/notices-sidebar.tsx
@@ -10,6 +10,7 @@ import { Link, type LinkProps } from "@tanstack/react-router";
 import {
 	BookOpen,
 	Bug,
+	Calendar,
 	FileText,
 	FolderOpen,
 	Group,
@@ -42,6 +43,11 @@ const items: SidebarItem[] = [
 		icon: <SprayCan />,
 		label: "Insecticides",
 		linkProps: { to: "/insecticides" },
+	},
+	{
+		icon: <Calendar />,
+		label: "Spray Schedule",
+		linkProps: { to: "/spray-schedule" },
 	},
 	{
 		icon: <FileText />,

--- a/apps/notices/src/components/spray-schedule-form.tsx
+++ b/apps/notices/src/components/spray-schedule-form.tsx
@@ -1,0 +1,147 @@
+import {
+	NonEmptyDateSchema,
+	NonEmptyStringSchema,
+	NonEmptyUUID,
+} from "@mcmec/lib/constants/validators";
+import type { SpraySchedulesRowType } from "@mcmec/supabase/db/spray-schedules";
+import { useAppForm } from "@mcmec/ui/forms/form-context";
+import type { ComboboxOption } from "@mcmec/ui/inputs/combobox-input";
+import type { MultiComboboxOption } from "@mcmec/ui/inputs/multi-combobox-input";
+import z from "zod";
+
+const STATUS_OPTIONS: ComboboxOption[] = [
+	{ label: "Scheduled", value: "scheduled" },
+	{ label: "Delayed", value: "delayed" },
+	{ label: "Cancelled", value: "cancelled" },
+	{ label: "Completed", value: "completed" },
+];
+
+const TimeStringSchema = z.string().min(1, "Time is required.");
+
+interface SprayScheduleFormValues extends SpraySchedulesRowType {
+	municipality_ids: string[];
+}
+
+interface SprayScheduleFormProps {
+	defaultValues: SprayScheduleFormValues;
+	onSubmit: (
+		value: SpraySchedulesRowType,
+		municipalityIds: string[],
+	) => void | Promise<void>;
+	insecticideOptions: ComboboxOption[];
+	municipalityOptions: MultiComboboxOption[];
+	formLabel: string;
+	submitLabel: string;
+}
+
+export function SprayScheduleForm({
+	defaultValues,
+	onSubmit,
+	insecticideOptions,
+	municipalityOptions,
+	formLabel,
+	submitLabel,
+}: SprayScheduleFormProps) {
+	const form = useAppForm({
+		defaultValues,
+		onSubmit: async ({ value }) => {
+			const { municipality_ids, ...scheduleValues } = value;
+			await onSubmit(scheduleValues as SpraySchedulesRowType, municipality_ids);
+		},
+	});
+
+	return (
+		<form.AppForm>
+			<form.FormWrapper className="max-w-2xl" formLabel={formLabel}>
+				<form.AppField
+					name="mission_date"
+					validators={{ onBlur: NonEmptyDateSchema }}
+				>
+					{(field) => (
+						<field.DateTimeField
+							label="Mission Date"
+							placeholder="Select date"
+							showTimeInput={false}
+						/>
+					)}
+				</form.AppField>
+				<form.AppField
+					name="start_time"
+					validators={{ onBlur: TimeStringSchema }}
+				>
+					{(field) => <field.TimeField label="Start Time" />}
+				</form.AppField>
+				<form.AppField
+					name="end_time"
+					validators={{ onBlur: TimeStringSchema }}
+				>
+					{(field) => <field.TimeField label="End Time" />}
+				</form.AppField>
+				<form.AppField name="rain_date">
+					{(field) => (
+						<field.DateTimeField
+							description="Optional backup date in case of rain."
+							label="Rain Date"
+							placeholder="Select rain date"
+							showTimeInput={false}
+						/>
+					)}
+				</form.AppField>
+				<form.AppField
+					name="area_description"
+					validators={{ onBlur: NonEmptyStringSchema(5) }}
+				>
+					{(field) => (
+						<field.TextAreaField
+							description="Describe the area(s) to be sprayed."
+							label="Area Description"
+						/>
+					)}
+				</form.AppField>
+				<form.AppField name="map_url">
+					{(field) => (
+						<field.TextField
+							description="Link to an external map showing the spray area."
+							label="Map URL"
+							showPaste={true}
+						/>
+					)}
+				</form.AppField>
+				<form.AppField name="status">
+					{(field) => (
+						<field.ComboboxField
+							label="Status"
+							options={STATUS_OPTIONS}
+							placeholder="Select status..."
+						/>
+					)}
+				</form.AppField>
+				<form.AppField
+					name="insecticide_id"
+					validators={{ onChange: NonEmptyUUID }}
+				>
+					{(field) => (
+						<field.ComboboxField
+							label="Insecticide"
+							options={insecticideOptions}
+							placeholder="Select insecticide..."
+						/>
+					)}
+				</form.AppField>
+				<form.AppField name="municipality_ids">
+					{(field) => (
+						<field.MultiComboboxField
+							description="Select the municipalities covered by this spray mission."
+							emptyMessage="No municipalities found."
+							label="Municipalities"
+							options={municipalityOptions}
+							placeholder="Select municipalities..."
+							searchPlaceholder="Search municipalities..."
+						/>
+					)}
+				</form.AppField>
+				<form.SubmitFormButton className="w-full" label={submitLabel} />
+			</form.FormWrapper>
+		</form.AppForm>
+	);
+}

--- a/apps/notices/src/components/spray-schedule-table.tsx
+++ b/apps/notices/src/components/spray-schedule-table.tsx
@@ -1,0 +1,291 @@
+import { formatDateShort } from "@mcmec/lib/functions/date-fns";
+import { Badge } from "@mcmec/ui/components/badge";
+import { Button } from "@mcmec/ui/components/button";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@mcmec/ui/components/select";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@mcmec/ui/components/table";
+import { useNavigate } from "@tanstack/react-router";
+import {
+	type ColumnDef,
+	flexRender,
+	getCoreRowModel,
+	getPaginationRowModel,
+	getSortedRowModel,
+	type SortingState,
+	useReactTable,
+} from "@tanstack/react-table";
+import { ArrowDown, ArrowUp, ArrowUpDown } from "lucide-react";
+import { useState } from "react";
+
+type SprayScheduleRow = {
+	id: string;
+	missionDate: Date;
+	startTime: string;
+	endTime: string;
+	status: string;
+	municipalityNames: string;
+	insecticideName: string;
+	areaDescription: string;
+};
+
+interface SprayScheduleTableProps {
+	data: SprayScheduleRow[];
+}
+
+function getStatusBadgeVariant(
+	status: string,
+): "default" | "secondary" | "outline" | "destructive" {
+	switch (status) {
+		case "scheduled":
+			return "default";
+		case "delayed":
+			return "outline";
+		case "cancelled":
+			return "destructive";
+		case "completed":
+			return "secondary";
+		default:
+			return "outline";
+	}
+}
+
+function formatTimeRange(startTime: string, endTime: string): string {
+	const format = (t: string) => {
+		const parts = t.split(":");
+		const h = Number.parseInt(parts[0] ?? "0", 10);
+		const ampm = h >= 12 ? "PM" : "AM";
+		const h12 = h % 12 || 12;
+		return `${h12}:${parts[1] ?? "00"} ${ampm}`;
+	};
+	return `${format(startTime)} – ${format(endTime)}`;
+}
+
+export function SprayScheduleTable({ data }: SprayScheduleTableProps) {
+	const navigate = useNavigate();
+	const [sorting, setSorting] = useState<SortingState>([
+		{ desc: true, id: "missionDate" },
+	]);
+
+	const columns: ColumnDef<SprayScheduleRow>[] = [
+		{
+			accessorKey: "missionDate",
+			cell: ({ row }) => {
+				const date = row.getValue("missionDate") as Date;
+				return formatDateShort(date);
+			},
+			header: ({ column }) => {
+				const sortState = column.getIsSorted();
+				return (
+					<Button
+						className="-ml-4"
+						onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+						variant="ghost"
+					>
+						Date
+						{sortState === "asc" ? (
+							<ArrowUp className="ml-2 h-4 w-4" />
+						) : sortState === "desc" ? (
+							<ArrowDown className="ml-2 h-4 w-4" />
+						) : (
+							<ArrowUpDown className="ml-2 h-4 w-4" />
+						)}
+					</Button>
+				);
+			},
+		},
+		{
+			accessorFn: (row) => formatTimeRange(row.startTime, row.endTime),
+			header: "Time",
+			id: "time",
+		},
+		{
+			accessorKey: "status",
+			cell: ({ row }) => {
+				const status = row.getValue("status") as string;
+				return (
+					<Badge variant={getStatusBadgeVariant(status)}>
+						{status.charAt(0).toUpperCase() + status.slice(1)}
+					</Badge>
+				);
+			},
+			header: ({ column }) => {
+				const sortState = column.getIsSorted();
+				return (
+					<Button
+						className="-ml-4"
+						onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+						variant="ghost"
+					>
+						Status
+						{sortState === "asc" ? (
+							<ArrowUp className="ml-2 h-4 w-4" />
+						) : sortState === "desc" ? (
+							<ArrowDown className="ml-2 h-4 w-4" />
+						) : (
+							<ArrowUpDown className="ml-2 h-4 w-4" />
+						)}
+					</Button>
+				);
+			},
+		},
+		{
+			accessorKey: "municipalityNames",
+			header: "Municipalities",
+		},
+		{
+			accessorKey: "insecticideName",
+			header: "Insecticide",
+		},
+		{
+			accessorKey: "areaDescription",
+			cell: ({ row }) => {
+				const desc = row.getValue("areaDescription") as string;
+				return (
+					<span className="line-clamp-1" title={desc}>
+						{desc}
+					</span>
+				);
+			},
+			header: "Area",
+		},
+	];
+
+	const table = useReactTable({
+		columns,
+		data,
+		getCoreRowModel: getCoreRowModel(),
+		getPaginationRowModel: getPaginationRowModel(),
+		getSortedRowModel: getSortedRowModel(),
+		initialState: {
+			pagination: {
+				pageSize: 10,
+			},
+		},
+		onSortingChange: setSorting,
+		state: {
+			sorting,
+		},
+	});
+
+	return (
+		<div className="space-y-4">
+			<div className="rounded-md border">
+				<Table>
+					<TableHeader>
+						{table.getHeaderGroups().map((headerGroup) => (
+							<TableRow key={headerGroup.id}>
+								{headerGroup.headers.map((header) => (
+									<TableHead key={header.id}>
+										{header.isPlaceholder
+											? null
+											: flexRender(
+													header.column.columnDef.header,
+													header.getContext(),
+												)}
+									</TableHead>
+								))}
+							</TableRow>
+						))}
+					</TableHeader>
+					<TableBody>
+						{table.getRowModel().rows?.length ? (
+							table.getRowModel().rows.map((row) => (
+								<TableRow
+									className="cursor-pointer"
+									data-state={row.getIsSelected() && "selected"}
+									key={row.id}
+									onClick={() =>
+										navigate({
+											params: {
+												sprayScheduleId: row.original.id,
+											},
+											to: "/spray-schedule/$sprayScheduleId",
+										})
+									}
+								>
+									{row.getVisibleCells().map((cell) => (
+										<TableCell key={cell.id}>
+											{flexRender(
+												cell.column.columnDef.cell,
+												cell.getContext(),
+											)}
+										</TableCell>
+									))}
+								</TableRow>
+							))
+						) : (
+							<TableRow>
+								<TableCell
+									className="h-24 text-center"
+									colSpan={columns.length}
+								>
+									No results.
+								</TableCell>
+							</TableRow>
+						)}
+					</TableBody>
+				</Table>
+			</div>
+
+			<div className="flex items-center justify-between px-2">
+				<div className="flex items-center space-x-2">
+					<p className="text-muted-foreground text-sm">Rows per page</p>
+					<Select
+						onValueChange={(value) => {
+							table.setPageSize(Number(value));
+						}}
+						value={`${table.getState().pagination.pageSize}`}
+					>
+						<SelectTrigger className="h-8 w-17.5">
+							<SelectValue placeholder={table.getState().pagination.pageSize} />
+						</SelectTrigger>
+						<SelectContent side="top">
+							{[10, 20, 30, 40, 50].map((pageSize) => (
+								<SelectItem key={pageSize} value={`${pageSize}`}>
+									{pageSize}
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
+				</div>
+
+				<div className="flex items-center space-x-6 lg:space-x-8">
+					<div className="flex w-25 items-center justify-center font-medium text-sm">
+						Page {table.getState().pagination.pageIndex + 1} of{" "}
+						{table.getPageCount()}
+					</div>
+					<div className="flex items-center space-x-2">
+						<Button
+							disabled={!table.getCanPreviousPage()}
+							onClick={() => table.previousPage()}
+							size="sm"
+							variant="outline"
+						>
+							Previous
+						</Button>
+						<Button
+							disabled={!table.getCanNextPage()}
+							onClick={() => table.nextPage()}
+							size="sm"
+							variant="outline"
+						>
+							Next
+						</Button>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/apps/notices/src/hooks/use-spray-schedules.ts
+++ b/apps/notices/src/hooks/use-spray-schedules.ts
@@ -1,0 +1,68 @@
+import { eq, useLiveQuery } from "@tanstack/react-db";
+import { useQuery } from "@tanstack/react-query";
+import {
+	employees,
+	insecticides,
+	municipalities,
+	spraySchedules,
+} from "../lib/db";
+import { supabase } from "../lib/queryClient";
+
+export function useSpraySchedules() {
+	const { data, collection } = useLiveQuery((q) =>
+		q
+			.from({ schedule: spraySchedules })
+			.innerJoin({ insecticide: insecticides }, ({ schedule, insecticide }) =>
+				eq(schedule.insecticide_id, insecticide.id),
+			)
+			.select(({ schedule, insecticide }) => ({
+				areaDescription: schedule.area_description,
+				createdById: schedule.created_by,
+				endTime: schedule.end_time,
+				id: schedule.id,
+				insecticideName: insecticide?.trade_name ?? "",
+				mapUrl: schedule.map_url,
+				missionDate: schedule.mission_date,
+				rainDate: schedule.rain_date,
+				startTime: schedule.start_time,
+				status: schedule.status,
+			})),
+	);
+
+	const { data: joinData } = useQuery({
+		queryFn: async () => {
+			const { data, error } = await supabase
+				.from("spray_schedule_municipalities")
+				.select("spray_schedule_id, municipality_id");
+			if (error) return [];
+			return data;
+		},
+		queryKey: ["spray_schedule_municipalities"],
+		refetchInterval: 5000,
+	});
+
+	const enriched = data.map((schedule) => {
+		const muniIds = (joinData ?? [])
+			.filter((j) => j.spray_schedule_id === schedule.id)
+			.map((j) => j.municipality_id);
+
+		const muniNames = muniIds
+			.map((id) => municipalities.get(id)?.name)
+			.filter((name): name is string => !!name)
+			.sort()
+			.join(", ");
+
+		const createdByName = schedule.createdById
+			? (employees.get(schedule.createdById)?.display_name ?? null)
+			: null;
+
+		return {
+			...schedule,
+			createdByName,
+			municipalityIds: muniIds,
+			municipalityNames: muniNames,
+		};
+	});
+
+	return { collection, data: enriched };
+}

--- a/apps/notices/src/lib/db.ts
+++ b/apps/notices/src/lib/db.ts
@@ -34,8 +34,10 @@ export const {
 	insecticides,
 	meetings,
 	mosquitofishRequests,
+	municipalities,
 	noticeTypes,
 	notices,
+	spraySchedules,
 	waterManagementRequests,
 	zipCodes,
 } = db;

--- a/apps/notices/src/routeTree.gen.ts
+++ b/apps/notices/src/routeTree.gen.ts
@@ -19,12 +19,15 @@ import { Route as appNoticesRouteRouteImport } from './routes/(app)/notices/rout
 import { Route as appMeetingsRouteRouteImport } from './routes/(app)/meetings/route'
 import { Route as appInsecticidesRouteRouteImport } from './routes/(app)/insecticides/route'
 import { Route as appContactSubmissionsRouteRouteImport } from './routes/(app)/contact-submissions/route'
+import { Route as appSprayScheduleIndexRouteImport } from './routes/(app)/spray-schedule/index'
 import { Route as appServiceRequestsIndexRouteImport } from './routes/(app)/service-requests/index'
 import { Route as appNoticesIndexRouteImport } from './routes/(app)/notices/index'
 import { Route as appMeetingsIndexRouteImport } from './routes/(app)/meetings/index'
 import { Route as appInsecticidesIndexRouteImport } from './routes/(app)/insecticides/index'
 import { Route as appDocumentsIndexRouteImport } from './routes/(app)/documents/index'
 import { Route as appContactSubmissionsIndexRouteImport } from './routes/(app)/contact-submissions/index'
+import { Route as appSprayScheduleCreateRouteImport } from './routes/(app)/spray-schedule/create'
+import { Route as appSprayScheduleSprayScheduleIdRouteImport } from './routes/(app)/spray-schedule/$sprayScheduleId'
 import { Route as appNoticesCreateRouteImport } from './routes/(app)/notices/create'
 import { Route as appNoticesNoticeIdRouteImport } from './routes/(app)/notices/$noticeId'
 import { Route as appMeetingsCreateRouteImport } from './routes/(app)/meetings/create'
@@ -98,6 +101,11 @@ const appContactSubmissionsRouteRoute =
     path: '/contact-submissions',
     getParentRoute: () => appRouteRoute,
   } as any)
+const appSprayScheduleIndexRoute = appSprayScheduleIndexRouteImport.update({
+  id: '/spray-schedule/',
+  path: '/spray-schedule/',
+  getParentRoute: () => appRouteRoute,
+} as any)
 const appServiceRequestsIndexRoute = appServiceRequestsIndexRouteImport.update({
   id: '/',
   path: '/',
@@ -128,6 +136,17 @@ const appContactSubmissionsIndexRoute =
     id: '/',
     path: '/',
     getParentRoute: () => appContactSubmissionsRouteRoute,
+  } as any)
+const appSprayScheduleCreateRoute = appSprayScheduleCreateRouteImport.update({
+  id: '/spray-schedule/create',
+  path: '/spray-schedule/create',
+  getParentRoute: () => appRouteRoute,
+} as any)
+const appSprayScheduleSprayScheduleIdRoute =
+  appSprayScheduleSprayScheduleIdRouteImport.update({
+    id: '/spray-schedule/$sprayScheduleId',
+    path: '/spray-schedule/$sprayScheduleId',
+    getParentRoute: () => appRouteRoute,
   } as any)
 const appNoticesCreateRoute = appNoticesCreateRouteImport.update({
   id: '/create',
@@ -274,12 +293,15 @@ export interface FileRoutesByFullPath {
   '/meetings/create': typeof appMeetingsCreateRoute
   '/notices/$noticeId': typeof appNoticesNoticeIdRoute
   '/notices/create': typeof appNoticesCreateRoute
+  '/spray-schedule/$sprayScheduleId': typeof appSprayScheduleSprayScheduleIdRoute
+  '/spray-schedule/create': typeof appSprayScheduleCreateRoute
   '/contact-submissions/': typeof appContactSubmissionsIndexRoute
   '/documents': typeof appDocumentsIndexRoute
   '/insecticides/': typeof appInsecticidesIndexRoute
   '/meetings/': typeof appMeetingsIndexRoute
   '/notices/': typeof appNoticesIndexRoute
   '/service-requests/': typeof appServiceRequestsIndexRoute
+  '/spray-schedule': typeof appSprayScheduleIndexRoute
   '/contact-submissions/$submissionId/edit': typeof appContactSubmissionsSubmissionIdEditRoute
   '/documents/$documentId/edit': typeof appDocumentsDocumentIdEditRoute
   '/notices/$noticeId/edit': typeof appNoticesNoticeIdEditRoute
@@ -308,12 +330,15 @@ export interface FileRoutesByTo {
   '/meetings/create': typeof appMeetingsCreateRoute
   '/notices/$noticeId': typeof appNoticesNoticeIdRoute
   '/notices/create': typeof appNoticesCreateRoute
+  '/spray-schedule/$sprayScheduleId': typeof appSprayScheduleSprayScheduleIdRoute
+  '/spray-schedule/create': typeof appSprayScheduleCreateRoute
   '/contact-submissions': typeof appContactSubmissionsIndexRoute
   '/documents': typeof appDocumentsIndexRoute
   '/insecticides': typeof appInsecticidesIndexRoute
   '/meetings': typeof appMeetingsIndexRoute
   '/notices': typeof appNoticesIndexRoute
   '/service-requests': typeof appServiceRequestsIndexRoute
+  '/spray-schedule': typeof appSprayScheduleIndexRoute
   '/contact-submissions/$submissionId/edit': typeof appContactSubmissionsSubmissionIdEditRoute
   '/documents/$documentId/edit': typeof appDocumentsDocumentIdEditRoute
   '/notices/$noticeId/edit': typeof appNoticesNoticeIdEditRoute
@@ -349,12 +374,15 @@ export interface FileRoutesById {
   '/(app)/meetings/create': typeof appMeetingsCreateRoute
   '/(app)/notices/$noticeId': typeof appNoticesNoticeIdRoute
   '/(app)/notices/create': typeof appNoticesCreateRoute
+  '/(app)/spray-schedule/$sprayScheduleId': typeof appSprayScheduleSprayScheduleIdRoute
+  '/(app)/spray-schedule/create': typeof appSprayScheduleCreateRoute
   '/(app)/contact-submissions/': typeof appContactSubmissionsIndexRoute
   '/(app)/documents/': typeof appDocumentsIndexRoute
   '/(app)/insecticides/': typeof appInsecticidesIndexRoute
   '/(app)/meetings/': typeof appMeetingsIndexRoute
   '/(app)/notices/': typeof appNoticesIndexRoute
   '/(app)/service-requests/': typeof appServiceRequestsIndexRoute
+  '/(app)/spray-schedule/': typeof appSprayScheduleIndexRoute
   '/(app)/contact-submissions/$submissionId_/edit': typeof appContactSubmissionsSubmissionIdEditRoute
   '/(app)/documents/$documentId_/edit': typeof appDocumentsDocumentIdEditRoute
   '/(app)/notices/$noticeId_/edit': typeof appNoticesNoticeIdEditRoute
@@ -390,12 +418,15 @@ export interface FileRouteTypes {
     | '/meetings/create'
     | '/notices/$noticeId'
     | '/notices/create'
+    | '/spray-schedule/$sprayScheduleId'
+    | '/spray-schedule/create'
     | '/contact-submissions/'
     | '/documents'
     | '/insecticides/'
     | '/meetings/'
     | '/notices/'
     | '/service-requests/'
+    | '/spray-schedule'
     | '/contact-submissions/$submissionId/edit'
     | '/documents/$documentId/edit'
     | '/notices/$noticeId/edit'
@@ -424,12 +455,15 @@ export interface FileRouteTypes {
     | '/meetings/create'
     | '/notices/$noticeId'
     | '/notices/create'
+    | '/spray-schedule/$sprayScheduleId'
+    | '/spray-schedule/create'
     | '/contact-submissions'
     | '/documents'
     | '/insecticides'
     | '/meetings'
     | '/notices'
     | '/service-requests'
+    | '/spray-schedule'
     | '/contact-submissions/$submissionId/edit'
     | '/documents/$documentId/edit'
     | '/notices/$noticeId/edit'
@@ -464,12 +498,15 @@ export interface FileRouteTypes {
     | '/(app)/meetings/create'
     | '/(app)/notices/$noticeId'
     | '/(app)/notices/create'
+    | '/(app)/spray-schedule/$sprayScheduleId'
+    | '/(app)/spray-schedule/create'
     | '/(app)/contact-submissions/'
     | '/(app)/documents/'
     | '/(app)/insecticides/'
     | '/(app)/meetings/'
     | '/(app)/notices/'
     | '/(app)/service-requests/'
+    | '/(app)/spray-schedule/'
     | '/(app)/contact-submissions/$submissionId_/edit'
     | '/(app)/documents/$documentId_/edit'
     | '/(app)/notices/$noticeId_/edit'
@@ -561,6 +598,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof appContactSubmissionsRouteRouteImport
       parentRoute: typeof appRouteRoute
     }
+    '/(app)/spray-schedule/': {
+      id: '/(app)/spray-schedule/'
+      path: '/spray-schedule'
+      fullPath: '/spray-schedule'
+      preLoaderRoute: typeof appSprayScheduleIndexRouteImport
+      parentRoute: typeof appRouteRoute
+    }
     '/(app)/service-requests/': {
       id: '/(app)/service-requests/'
       path: '/'
@@ -602,6 +646,20 @@ declare module '@tanstack/react-router' {
       fullPath: '/contact-submissions/'
       preLoaderRoute: typeof appContactSubmissionsIndexRouteImport
       parentRoute: typeof appContactSubmissionsRouteRoute
+    }
+    '/(app)/spray-schedule/create': {
+      id: '/(app)/spray-schedule/create'
+      path: '/spray-schedule/create'
+      fullPath: '/spray-schedule/create'
+      preLoaderRoute: typeof appSprayScheduleCreateRouteImport
+      parentRoute: typeof appRouteRoute
+    }
+    '/(app)/spray-schedule/$sprayScheduleId': {
+      id: '/(app)/spray-schedule/$sprayScheduleId'
+      path: '/spray-schedule/$sprayScheduleId'
+      fullPath: '/spray-schedule/$sprayScheduleId'
+      preLoaderRoute: typeof appSprayScheduleSprayScheduleIdRouteImport
+      parentRoute: typeof appRouteRoute
     }
     '/(app)/notices/create': {
       id: '/(app)/notices/create'
@@ -882,7 +940,10 @@ interface appRouteRouteChildren {
   appIndexRoute: typeof appIndexRoute
   appDocumentsDocumentIdRoute: typeof appDocumentsDocumentIdRoute
   appDocumentsCreateRoute: typeof appDocumentsCreateRoute
+  appSprayScheduleSprayScheduleIdRoute: typeof appSprayScheduleSprayScheduleIdRoute
+  appSprayScheduleCreateRoute: typeof appSprayScheduleCreateRoute
   appDocumentsIndexRoute: typeof appDocumentsIndexRoute
+  appSprayScheduleIndexRoute: typeof appSprayScheduleIndexRoute
   appDocumentsDocumentIdEditRoute: typeof appDocumentsDocumentIdEditRoute
 }
 
@@ -897,7 +958,10 @@ const appRouteRouteChildren: appRouteRouteChildren = {
   appIndexRoute: appIndexRoute,
   appDocumentsDocumentIdRoute: appDocumentsDocumentIdRoute,
   appDocumentsCreateRoute: appDocumentsCreateRoute,
+  appSprayScheduleSprayScheduleIdRoute: appSprayScheduleSprayScheduleIdRoute,
+  appSprayScheduleCreateRoute: appSprayScheduleCreateRoute,
   appDocumentsIndexRoute: appDocumentsIndexRoute,
+  appSprayScheduleIndexRoute: appSprayScheduleIndexRoute,
   appDocumentsDocumentIdEditRoute: appDocumentsDocumentIdEditRoute,
 }
 

--- a/apps/notices/src/routes/(app)/index.tsx
+++ b/apps/notices/src/routes/(app)/index.tsx
@@ -17,10 +17,12 @@ import { createFileRoute, Link } from "@tanstack/react-router";
 import {
 	BookOpen,
 	Bug,
+	Calendar,
 	CheckCircle,
 	Clock,
 	Mail,
 	MailOpen,
+	SprayCan,
 	Users,
 } from "lucide-react";
 
@@ -109,6 +111,43 @@ function RouteComponent() {
 			.limit(5),
 	);
 
+	// Spray schedule data
+	const { data: scheduledMissions } = useLiveQuery((q) =>
+		q
+			.from({ s: db.spraySchedules })
+			.where(({ s }) => eq(s.status, "scheduled"))
+			.orderBy(({ s }) => s.mission_date, "asc"),
+	);
+
+	const { data: delayedMissions } = useLiveQuery((q) =>
+		q.from({ s: db.spraySchedules }).where(({ s }) => eq(s.status, "delayed")),
+	);
+
+	const { data: completedMissions } = useLiveQuery((q) =>
+		q
+			.from({ s: db.spraySchedules })
+			.where(({ s }) => eq(s.status, "completed")),
+	);
+
+	const { data: recentMissions } = useLiveQuery((q) =>
+		q
+			.from({ s: db.spraySchedules })
+			.innerJoin({ i: db.insecticides }, ({ s, i }) =>
+				eq(s.insecticide_id, i.id),
+			)
+			.select(({ s, i }) => ({
+				areaDescription: s.area_description,
+				endTime: s.end_time,
+				id: s.id,
+				insecticideName: i?.trade_name ?? "",
+				missionDate: s.mission_date,
+				startTime: s.start_time,
+				status: s.status,
+			}))
+			.orderBy(({ s }) => s.mission_date, "desc")
+			.limit(5),
+	);
+
 	const totalPendingRequests =
 		pendingAdultMosquito.length +
 		pendingMosquitofish.length +
@@ -124,7 +163,7 @@ function RouteComponent() {
 			</div>
 
 			{/* Stats Row */}
-			<div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+			<div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-5">
 				<Card>
 					<CardHeader className="flex flex-row items-center justify-between pb-2">
 						<CardTitle className="font-medium text-sm">
@@ -182,6 +221,22 @@ function RouteComponent() {
 					<CardContent>
 						<div className="font-bold text-2xl">{upcomingMeetings.length}</div>
 						<p className="text-muted-foreground text-xs">scheduled</p>
+					</CardContent>
+				</Card>
+
+				<Card>
+					<CardHeader className="flex flex-row items-center justify-between pb-2">
+						<CardTitle className="font-medium text-sm">
+							Spray Missions
+						</CardTitle>
+						<SprayCan className="h-4 w-4 text-muted-foreground" />
+					</CardHeader>
+					<CardContent>
+						<div className="font-bold text-2xl">{scheduledMissions.length}</div>
+						<p className="text-muted-foreground text-xs">
+							{delayedMissions.length} delayed, {completedMissions.length}{" "}
+							completed
+						</p>
 					</CardContent>
 				</Card>
 			</div>
@@ -467,6 +522,65 @@ function RouteComponent() {
 								<Users className="mb-2 h-8 w-8 text-muted-foreground" />
 								<p className="text-muted-foreground text-sm">
 									No upcoming meetings
+								</p>
+							</div>
+						)}
+					</CardContent>
+				</Card>
+				{/* Spray Schedule */}
+				<Card>
+					<CardHeader>
+						<div className="flex items-center justify-between">
+							<div>
+								<CardTitle>Spray Schedule</CardTitle>
+								<CardDescription>Recent and upcoming missions</CardDescription>
+							</div>
+							<Button asChild size="sm" variant="outline">
+								<Link to="/spray-schedule">View All</Link>
+							</Button>
+						</div>
+					</CardHeader>
+					<CardContent>
+						{recentMissions.length > 0 ? (
+							<ul className="space-y-3">
+								{recentMissions.map((m) => (
+									<li key={m.id}>
+										<Link
+											className="flex items-center justify-between rounded-md p-2 transition-colors hover:bg-muted"
+											params={{ sprayScheduleId: m.id }}
+											to="/spray-schedule/$sprayScheduleId"
+										>
+											<div className="flex-1">
+												<p className="line-clamp-1 font-medium">
+													{m.areaDescription}
+												</p>
+												<div className="flex items-center gap-1 text-muted-foreground text-sm">
+													<Calendar className="h-3 w-3" />
+													{formatDateShort(m.missionDate)}
+												</div>
+											</div>
+											<Badge
+												variant={
+													m.status === "scheduled"
+														? "default"
+														: m.status === "delayed"
+															? "outline"
+															: m.status === "cancelled"
+																? "destructive"
+																: "secondary"
+												}
+											>
+												{m.status.charAt(0).toUpperCase() + m.status.slice(1)}
+											</Badge>
+										</Link>
+									</li>
+								))}
+							</ul>
+						) : (
+							<div className="flex flex-col items-center justify-center py-8 text-center">
+								<SprayCan className="mb-2 h-8 w-8 text-muted-foreground" />
+								<p className="text-muted-foreground text-sm">
+									No spray missions
 								</p>
 							</div>
 						)}

--- a/apps/notices/src/routes/(app)/spray-schedule/$sprayScheduleId.tsx
+++ b/apps/notices/src/routes/(app)/spray-schedule/$sprayScheduleId.tsx
@@ -1,0 +1,144 @@
+import { ErrorMessages } from "@mcmec/lib/constants/errors";
+import type { SpraySchedulesRowType } from "@mcmec/supabase/db/spray-schedules";
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+	AlertDialogTrigger,
+} from "@mcmec/ui/components/alert-dialog";
+import { Button } from "@mcmec/ui/components/button";
+import { useLiveQuery } from "@tanstack/react-db";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { createFileRoute } from "@tanstack/react-router";
+import { SprayScheduleForm } from "@/src/components/spray-schedule-form";
+import { insecticides, municipalities, spraySchedules } from "@/src/lib/db";
+import { supabase } from "@/src/lib/queryClient";
+import { toastOnError } from "@/src/lib/toast-on-error";
+
+export const Route = createFileRoute("/(app)/spray-schedule/$sprayScheduleId")({
+	component: RouteComponent,
+	loader: async ({ params }) => {
+		await spraySchedules.preload();
+		const schedule = spraySchedules.get(params.sprayScheduleId);
+		if (!schedule) {
+			throw new Error(ErrorMessages.DATABASE.RECORD_NOT_AVAILABLE);
+		}
+		return { crumb: "Edit", schedule };
+	},
+});
+
+function RouteComponent() {
+	const navigate = Route.useNavigate();
+	const queryClient = useQueryClient();
+	const { schedule } = Route.useLoaderData();
+	const { sprayScheduleId } = Route.useParams();
+
+	const { data: insecticideData } = useLiveQuery((q) =>
+		q.from({ insecticide: insecticides }).select(({ insecticide }) => ({
+			label: insecticide.trade_name,
+			value: insecticide.id,
+		})),
+	);
+
+	const { data: municipalityData } = useLiveQuery((q) =>
+		q.from({ municipality: municipalities }).select(({ municipality }) => ({
+			label: municipality.name,
+			value: municipality.id,
+		})),
+	);
+
+	const { data: currentMunicipalityIds } = useQuery({
+		queryFn: async () => {
+			const { data, error } = await supabase
+				.from("spray_schedule_municipalities")
+				.select("municipality_id")
+				.eq("spray_schedule_id", sprayScheduleId);
+			if (error) return [];
+			return data.map((m) => m.municipality_id);
+		},
+		queryKey: ["spray_schedule_municipalities", sprayScheduleId],
+	});
+
+	const handleSubmit = async (
+		value: SpraySchedulesRowType,
+		municipalityIds: string[],
+	) => {
+		const tx = spraySchedules.update(sprayScheduleId, (draft) => {
+			Object.assign(draft, value);
+		});
+		toastOnError(tx, "Failed to update spray schedule.");
+
+		// Replace municipality links
+		await supabase
+			.from("spray_schedule_municipalities")
+			.delete()
+			.eq("spray_schedule_id", sprayScheduleId);
+
+		if (municipalityIds.length > 0) {
+			// biome-ignore lint/suspicious/noExplicitAny: table not yet in generated types
+			await (supabase as any).from("spray_schedule_municipalities").insert(
+				municipalityIds.map((muniId) => ({
+					municipality_id: muniId,
+					spray_schedule_id: sprayScheduleId,
+				})),
+			);
+		}
+
+		queryClient.invalidateQueries({
+			queryKey: ["spray_schedule_municipalities"],
+		});
+		navigate({ to: "/spray-schedule" });
+	};
+
+	const handleDelete = async () => {
+		const tx = spraySchedules.delete(sprayScheduleId);
+		toastOnError(tx, "Failed to delete spray schedule.");
+		navigate({ to: "/spray-schedule" });
+	};
+
+	return (
+		<div className="space-y-4">
+			<SprayScheduleForm
+				defaultValues={{
+					...schedule,
+					municipality_ids: currentMunicipalityIds ?? [],
+				}}
+				formLabel="Edit Spray Mission"
+				insecticideOptions={insecticideData}
+				municipalityOptions={municipalityData}
+				onSubmit={handleSubmit}
+				submitLabel="Update"
+			/>
+
+			<div className="max-w-2xl">
+				<AlertDialog>
+					<AlertDialogTrigger asChild>
+						<Button className="w-full" variant="destructive">
+							Delete Spray Mission
+						</Button>
+					</AlertDialogTrigger>
+					<AlertDialogContent>
+						<AlertDialogHeader>
+							<AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>
+							<AlertDialogDescription>
+								This action cannot be undone. This will permanently delete this
+								spray schedule entry.
+							</AlertDialogDescription>
+						</AlertDialogHeader>
+						<AlertDialogFooter>
+							<AlertDialogCancel>Cancel</AlertDialogCancel>
+							<AlertDialogAction onClick={handleDelete}>
+								Delete
+							</AlertDialogAction>
+						</AlertDialogFooter>
+					</AlertDialogContent>
+				</AlertDialog>
+			</div>
+		</div>
+	);
+}

--- a/apps/notices/src/routes/(app)/spray-schedule/create.tsx
+++ b/apps/notices/src/routes/(app)/spray-schedule/create.tsx
@@ -1,0 +1,82 @@
+import type { SpraySchedulesRowType } from "@mcmec/supabase/db/spray-schedules";
+import { useLiveQuery } from "@tanstack/react-db";
+import { useQueryClient } from "@tanstack/react-query";
+import { createFileRoute } from "@tanstack/react-router";
+import { SprayScheduleForm } from "@/src/components/spray-schedule-form";
+import { insecticides, municipalities, spraySchedules } from "@/src/lib/db";
+import { supabase } from "@/src/lib/queryClient";
+import { toastOnError } from "@/src/lib/toast-on-error";
+
+export const Route = createFileRoute("/(app)/spray-schedule/create")({
+	component: RouteComponent,
+	loader: () => {
+		return { crumb: "Create" };
+	},
+});
+
+function RouteComponent() {
+	const navigate = Route.useNavigate();
+	const queryClient = useQueryClient();
+
+	const { data: insecticideData } = useLiveQuery((q) =>
+		q.from({ insecticide: insecticides }).select(({ insecticide }) => ({
+			label: insecticide.trade_name,
+			value: insecticide.id,
+		})),
+	);
+
+	const { data: municipalityData } = useLiveQuery((q) =>
+		q.from({ municipality: municipalities }).select(({ municipality }) => ({
+			label: municipality.name,
+			value: municipality.id,
+		})),
+	);
+
+	const handleSubmit = async (
+		value: SpraySchedulesRowType,
+		municipalityIds: string[],
+	) => {
+		const tx = spraySchedules.insert(value);
+		toastOnError(tx, "Failed to create spray schedule.");
+
+		if (municipalityIds.length > 0) {
+			await supabase.from("spray_schedule_municipalities").insert(
+				municipalityIds.map((municipalityId) => ({
+					municipality_id: municipalityId,
+					spray_schedule_id: value.id,
+				})),
+			);
+			queryClient.invalidateQueries({
+				queryKey: ["spray_schedule_municipalities"],
+			});
+		}
+
+		navigate({ to: "/spray-schedule" });
+	};
+
+	return (
+		<SprayScheduleForm
+			defaultValues={{
+				area_description: "",
+				created_at: new Date(),
+				created_by: null,
+				end_time: "23:00",
+				id: crypto.randomUUID(),
+				insecticide_id: "",
+				map_url: null,
+				mission_date: new Date(),
+				municipality_ids: [],
+				rain_date: null,
+				start_time: "19:00",
+				status: "scheduled",
+				updated_at: new Date(),
+				updated_by: null,
+			}}
+			formLabel="Create New Spray Mission"
+			insecticideOptions={insecticideData}
+			municipalityOptions={municipalityData}
+			onSubmit={handleSubmit}
+			submitLabel="Create"
+		/>
+	);
+}

--- a/apps/notices/src/routes/(app)/spray-schedule/index.tsx
+++ b/apps/notices/src/routes/(app)/spray-schedule/index.tsx
@@ -1,0 +1,41 @@
+import { Button } from "@mcmec/ui/components/button";
+import { createFileRoute } from "@tanstack/react-router";
+import { Plus } from "lucide-react";
+import { SprayScheduleTable } from "@/src/components/spray-schedule-table";
+import { useSpraySchedules } from "@/src/hooks/use-spray-schedules";
+
+export const Route = createFileRoute("/(app)/spray-schedule/")({
+	component: RouteComponent,
+	loader: () => {
+		return { crumb: "Spray Schedule" };
+	},
+});
+
+function RouteComponent() {
+	const navigate = Route.useNavigate();
+	const { data: schedules } = useSpraySchedules();
+
+	const tableData = schedules.map((schedule) => ({
+		areaDescription: schedule.areaDescription,
+		endTime: schedule.endTime,
+		id: schedule.id,
+		insecticideName: schedule.insecticideName ?? "",
+		missionDate: schedule.missionDate,
+		municipalityNames: schedule.municipalityNames,
+		startTime: schedule.startTime,
+		status: schedule.status,
+	}));
+
+	return (
+		<div className="space-y-4">
+			<div className="flex items-center justify-between">
+				<h1 className="font-semibold text-2xl">Spray Schedule</h1>
+				<Button onClick={() => navigate({ to: "/spray-schedule/create" })}>
+					<Plus />
+					Create New Mission
+				</Button>
+			</div>
+			<SprayScheduleTable data={tableData} />
+		</div>
+	);
+}

--- a/apps/public/src/components/nav-bar.tsx
+++ b/apps/public/src/components/nav-bar.tsx
@@ -64,6 +64,11 @@ const menuItems: MenuItem[] = [
 				linkProps: { to: "/about/job-opportunities" },
 				title: "Job Opportunities",
 			},
+			{
+				description: "View upcoming mosquito spray missions.",
+				linkProps: { to: "/spray-schedule" },
+				title: "Spray Schedule",
+			},
 		],
 		title: "About",
 	},

--- a/apps/public/src/components/spray-schedule-card.tsx
+++ b/apps/public/src/components/spray-schedule-card.tsx
@@ -1,0 +1,154 @@
+import { formatDate } from "@mcmec/lib/functions/date-fns";
+import { Badge } from "@mcmec/ui/components/badge";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@mcmec/ui/components/card";
+import { ExternalLink, MapPin } from "lucide-react";
+
+interface SprayScheduleCardProps {
+	missionDate: Date;
+	startTime: string;
+	endTime: string;
+	rainDate: Date | null;
+	status: string;
+	municipalities: string;
+	areaDescription: string;
+	insecticideName: string;
+	insecticideLabelUrl: string | null;
+	insecticideMsdsUrl: string | null;
+	mapUrl: string | null;
+}
+
+function getStatusBadgeVariant(
+	status: string,
+): "default" | "secondary" | "outline" | "destructive" {
+	switch (status) {
+		case "scheduled":
+			return "default";
+		case "delayed":
+			return "outline";
+		case "cancelled":
+			return "destructive";
+		case "completed":
+			return "secondary";
+		default:
+			return "outline";
+	}
+}
+
+function formatTimeDisplay(time: string): string {
+	const parts = time.split(":");
+	const h = Number.parseInt(parts[0] ?? "0", 10);
+	const ampm = h >= 12 ? "PM" : "AM";
+	const h12 = h % 12 || 12;
+	return `${h12}:${parts[1] ?? "00"} ${ampm}`;
+}
+
+export function SprayScheduleCard({
+	missionDate,
+	startTime,
+	endTime,
+	rainDate,
+	status,
+	municipalities,
+	areaDescription,
+	insecticideName,
+	insecticideLabelUrl,
+	insecticideMsdsUrl,
+	mapUrl,
+}: SprayScheduleCardProps) {
+	return (
+		<Card>
+			<CardHeader>
+				<div className="flex items-start justify-between gap-2">
+					<div>
+						<CardTitle className="text-xl">{formatDate(missionDate)}</CardTitle>
+						<CardDescription className="text-base">
+							{formatTimeDisplay(startTime)} – {formatTimeDisplay(endTime)}
+						</CardDescription>
+					</div>
+					<Badge variant={getStatusBadgeVariant(status)}>
+						{status.charAt(0).toUpperCase() + status.slice(1)}
+					</Badge>
+				</div>
+			</CardHeader>
+			<CardContent>
+				<dl className="grid gap-3 text-sm">
+					<div className="flex items-start gap-2">
+						<dt className="min-w-32 font-semibold text-muted-foreground">
+							Municipalities
+						</dt>
+						<dd>{municipalities}</dd>
+					</div>
+					<div className="flex items-start gap-2">
+						<dt className="min-w-32 font-semibold text-muted-foreground">
+							Area
+						</dt>
+						<dd>{areaDescription}</dd>
+					</div>
+					<div className="flex items-start gap-2">
+						<dt className="min-w-32 font-semibold text-muted-foreground">
+							Insecticide
+						</dt>
+						<dd className="flex flex-wrap items-center gap-x-3 gap-y-1">
+							<span>{insecticideName}</span>
+							{insecticideLabelUrl && (
+								<a
+									className="inline-flex items-center gap-1 text-primary text-xs underline hover:no-underline"
+									href={insecticideLabelUrl}
+									rel="noopener noreferrer"
+									target="_blank"
+								>
+									Label
+									<ExternalLink className="h-3 w-3" />
+								</a>
+							)}
+							{insecticideMsdsUrl && (
+								<a
+									className="inline-flex items-center gap-1 text-primary text-xs underline hover:no-underline"
+									href={insecticideMsdsUrl}
+									rel="noopener noreferrer"
+									target="_blank"
+								>
+									SDS
+									<ExternalLink className="h-3 w-3" />
+								</a>
+							)}
+						</dd>
+					</div>
+					{rainDate && (
+						<div className="flex items-start gap-2">
+							<dt className="min-w-32 font-semibold text-muted-foreground">
+								Rain Date
+							</dt>
+							<dd>{formatDate(rainDate)}</dd>
+						</div>
+					)}
+					{mapUrl && (
+						<div className="flex items-start gap-2">
+							<dt className="min-w-32 font-semibold text-muted-foreground">
+								Map
+							</dt>
+							<dd>
+								<a
+									className="inline-flex items-center gap-1 text-primary underline hover:no-underline"
+									href={mapUrl}
+									rel="noopener noreferrer"
+									target="_blank"
+								>
+									<MapPin className="h-4 w-4" />
+									View Spray Area Map
+									<ExternalLink className="h-3 w-3" />
+								</a>
+							</dd>
+						</div>
+					)}
+				</dl>
+			</CardContent>
+		</Card>
+	);
+}

--- a/apps/public/src/components/spray-schedule-filters.tsx
+++ b/apps/public/src/components/spray-schedule-filters.tsx
@@ -1,0 +1,62 @@
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@mcmec/ui/components/select";
+
+interface SprayScheduleFiltersProps {
+	municipalities: Array<{ id: string; name: string }>;
+	selectedMunicipality: string;
+	onMunicipalityChange: (value: string) => void;
+	selectedStatus: string;
+	onStatusChange: (value: string) => void;
+}
+
+const STATUS_OPTIONS = [
+	{ label: "All Statuses", value: "all" },
+	{ label: "Scheduled", value: "scheduled" },
+	{ label: "Delayed", value: "delayed" },
+	{ label: "Cancelled", value: "cancelled" },
+	{ label: "Completed", value: "completed" },
+];
+
+export function SprayScheduleFilters({
+	municipalities,
+	selectedMunicipality,
+	onMunicipalityChange,
+	selectedStatus,
+	onStatusChange,
+}: SprayScheduleFiltersProps) {
+	return (
+		<div className="flex flex-wrap gap-4">
+			<Select onValueChange={onMunicipalityChange} value={selectedMunicipality}>
+				<SelectTrigger className="w-60">
+					<SelectValue placeholder="All Municipalities" />
+				</SelectTrigger>
+				<SelectContent>
+					<SelectItem value="all">All Municipalities</SelectItem>
+					{municipalities.map((m) => (
+						<SelectItem key={m.id} value={m.id}>
+							{m.name}
+						</SelectItem>
+					))}
+				</SelectContent>
+			</Select>
+
+			<Select onValueChange={onStatusChange} value={selectedStatus}>
+				<SelectTrigger className="w-48">
+					<SelectValue placeholder="All Statuses" />
+				</SelectTrigger>
+				<SelectContent>
+					{STATUS_OPTIONS.map((option) => (
+						<SelectItem key={option.value} value={option.value}>
+							{option.label}
+						</SelectItem>
+					))}
+				</SelectContent>
+			</Select>
+		</div>
+	);
+}

--- a/apps/public/src/lib/queries.ts
+++ b/apps/public/src/lib/queries.ts
@@ -4,8 +4,10 @@ import { DocumentsRowSchema } from "@mcmec/supabase/db/documents";
 import { InsecticidesRowSchema } from "@mcmec/supabase/db/insecticides";
 import { JobPostingsRowSchema } from "@mcmec/supabase/db/job-postings";
 import { MeetingsRowSchema } from "@mcmec/supabase/db/meetings";
+import { MunicipalitiesRowSchema } from "@mcmec/supabase/db/municipalities";
 import { NoticeTypesRowSchema } from "@mcmec/supabase/db/notice-types";
 import { NoticesRowSchema } from "@mcmec/supabase/db/notices";
+import { SpraySchedulesRowSchema } from "@mcmec/supabase/db/spray-schedules";
 import { ZipCodesRowSchema } from "@mcmec/supabase/db/zip-codes";
 import { queryOptions } from "@tanstack/react-query";
 import { createServerFn } from "@tanstack/react-start";
@@ -196,5 +198,62 @@ export const jobPostingsQueryOptions = () =>
 	queryOptions({
 		queryFn: () => getJobPostingsServerFn(),
 		queryKey: ["job_postings"],
+		staleTime: 1000 * 60 * 60, // 1 hour
+	});
+
+const getSpraySchedulesServerFn = createServerFn({ method: "GET" }).handler(
+	async () => {
+		const supabase = getSupabaseServerClient();
+		const currentYear = new Date().getFullYear();
+		const { data, error } = await supabase
+			.from("spray_schedules")
+			.select(
+				"*, insecticides(trade_name, label_url, msds_url), spray_schedule_municipalities(municipality_id, municipalities(name))",
+			)
+			.gte("mission_date", `${currentYear}-01-01`)
+			.lte("mission_date", `${currentYear}-12-31`);
+		if (error) {
+			throw new Error(
+				ErrorMessages.DATABASE.UNABLE_TO_FETCH("spray_schedules"),
+			);
+		}
+		return data.map((row) => ({
+			...SpraySchedulesRowSchema.parse(row),
+			insecticideLabelUrl: row.insecticides?.label_url ?? null,
+			insecticideMsdsUrl: row.insecticides?.msds_url ?? null,
+			insecticideName: row.insecticides?.trade_name ?? "",
+			municipalities: row.spray_schedule_municipalities.map((m) => ({
+				id: m.municipality_id,
+				name: m.municipalities?.name ?? "",
+			})),
+		}));
+	},
+);
+
+export const spraySchedulesQueryOptions = () =>
+	queryOptions({
+		queryFn: () => getSpraySchedulesServerFn(),
+		queryKey: ["spray_schedules"],
+		staleTime: 1000 * 60 * 30, // 30 minutes
+	});
+
+const getMunicipalitiesServerFn = createServerFn({ method: "GET" }).handler(
+	async () => {
+		const supabase = getSupabaseServerClient();
+		const { data, error } = await supabase
+			.from("municipalities")
+			.select("*")
+			.order("name");
+		if (error) {
+			throw new Error(ErrorMessages.DATABASE.UNABLE_TO_FETCH("municipalities"));
+		}
+		return data.map((m) => MunicipalitiesRowSchema.parse(m));
+	},
+);
+
+export const municipalitiesQueryOptions = () =>
+	queryOptions({
+		queryFn: () => getMunicipalitiesServerFn(),
+		queryKey: ["municipalities"],
 		staleTime: 1000 * 60 * 60, // 1 hour
 	});

--- a/apps/public/src/routeTree.gen.ts
+++ b/apps/public/src/routeTree.gen.ts
@@ -9,6 +9,7 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as SprayScheduleRouteImport } from './routes/spray-schedule'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as NoticesIndexRouteImport } from './routes/notices/index'
 import { Route as NoticesTransparencyRouteImport } from './routes/notices/transparency'
@@ -28,6 +29,11 @@ import { Route as AboutHowWeControlMosquitoesRouteImport } from './routes/about/
 import { Route as AboutJobOpportunitiesIndexRouteImport } from './routes/about/job-opportunities/index'
 import { Route as AboutJobOpportunitiesPostingIdRouteImport } from './routes/about/job-opportunities/$postingId'
 
+const SprayScheduleRoute = SprayScheduleRouteImport.update({
+  id: '/spray-schedule',
+  path: '/spray-schedule',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
@@ -128,6 +134,7 @@ const AboutJobOpportunitiesPostingIdRoute =
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/spray-schedule': typeof SprayScheduleRoute
   '/about/how-we-control-mosquitoes': typeof AboutHowWeControlMosquitoesRoute
   '/about/leadership': typeof AboutLeadershipRoute
   '/about/mission': typeof AboutMissionRoute
@@ -148,6 +155,7 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/spray-schedule': typeof SprayScheduleRoute
   '/about/how-we-control-mosquitoes': typeof AboutHowWeControlMosquitoesRoute
   '/about/leadership': typeof AboutLeadershipRoute
   '/about/mission': typeof AboutMissionRoute
@@ -169,6 +177,7 @@ export interface FileRoutesByTo {
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/spray-schedule': typeof SprayScheduleRoute
   '/about/how-we-control-mosquitoes': typeof AboutHowWeControlMosquitoesRoute
   '/about/leadership': typeof AboutLeadershipRoute
   '/about/mission': typeof AboutMissionRoute
@@ -191,6 +200,7 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/spray-schedule'
     | '/about/how-we-control-mosquitoes'
     | '/about/leadership'
     | '/about/mission'
@@ -211,6 +221,7 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/spray-schedule'
     | '/about/how-we-control-mosquitoes'
     | '/about/leadership'
     | '/about/mission'
@@ -231,6 +242,7 @@ export interface FileRouteTypes {
   id:
     | '__root__'
     | '/'
+    | '/spray-schedule'
     | '/about/how-we-control-mosquitoes'
     | '/about/leadership'
     | '/about/mission'
@@ -252,6 +264,7 @@ export interface FileRouteTypes {
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  SprayScheduleRoute: typeof SprayScheduleRoute
   AboutHowWeControlMosquitoesRoute: typeof AboutHowWeControlMosquitoesRoute
   AboutLeadershipRoute: typeof AboutLeadershipRoute
   AboutMissionRoute: typeof AboutMissionRoute
@@ -273,6 +286,13 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/spray-schedule': {
+      id: '/spray-schedule'
+      path: '/spray-schedule'
+      fullPath: '/spray-schedule'
+      preLoaderRoute: typeof SprayScheduleRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/': {
       id: '/'
       path: '/'
@@ -404,6 +424,7 @@ declare module '@tanstack/react-router' {
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  SprayScheduleRoute: SprayScheduleRoute,
   AboutHowWeControlMosquitoesRoute: AboutHowWeControlMosquitoesRoute,
   AboutLeadershipRoute: AboutLeadershipRoute,
   AboutMissionRoute: AboutMissionRoute,

--- a/apps/public/src/routes/spray-schedule.tsx
+++ b/apps/public/src/routes/spray-schedule.tsx
@@ -1,0 +1,104 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { createFileRoute } from "@tanstack/react-router";
+import { useMemo, useState } from "react";
+import { SprayScheduleCard } from "../components/spray-schedule-card";
+import { SprayScheduleFilters } from "../components/spray-schedule-filters";
+import {
+	municipalitiesQueryOptions,
+	spraySchedulesQueryOptions,
+} from "../lib/queries";
+
+export const Route = createFileRoute("/spray-schedule")({
+	component: RouteComponent,
+	loader: async ({ context }) => {
+		await Promise.all([
+			context.queryClient.ensureQueryData(spraySchedulesQueryOptions()),
+			context.queryClient.ensureQueryData(municipalitiesQueryOptions()),
+		]);
+	},
+});
+
+function RouteComponent() {
+	const { data: schedules } = useSuspenseQuery(spraySchedulesQueryOptions());
+	const { data: municipalitiesData } = useSuspenseQuery(
+		municipalitiesQueryOptions(),
+	);
+
+	const [selectedMunicipality, setSelectedMunicipality] = useState("all");
+	const [selectedStatus, setSelectedStatus] = useState("all");
+
+	const municipalitiesList = municipalitiesData.map((m) => ({
+		id: m.id,
+		name: m.name,
+	}));
+
+	const filteredSchedules = useMemo(() => {
+		return schedules
+			.filter((s) => {
+				if (
+					selectedMunicipality !== "all" &&
+					!s.municipalities.some((m) => m.id === selectedMunicipality)
+				) {
+					return false;
+				}
+				if (selectedStatus !== "all" && s.status !== selectedStatus) {
+					return false;
+				}
+				return true;
+			})
+			.sort(
+				(a, b) =>
+					new Date(b.mission_date).getTime() -
+					new Date(a.mission_date).getTime(),
+			);
+	}, [schedules, selectedMunicipality, selectedStatus]);
+
+	return (
+		<div className="flex flex-col gap-6">
+			<article className="prose lg:prose-xl max-w-none">
+				<h1>Mosquito Spray Schedule</h1>
+				<p>
+					View upcoming and past mosquito spray missions conducted by the
+					Middlesex County Mosquito Extermination Commission. Spray operations
+					are weather-dependent and may be delayed or cancelled.
+				</p>
+			</article>
+
+			<SprayScheduleFilters
+				municipalities={municipalitiesList}
+				onMunicipalityChange={setSelectedMunicipality}
+				onStatusChange={setSelectedStatus}
+				selectedMunicipality={selectedMunicipality}
+				selectedStatus={selectedStatus}
+			/>
+
+			<div className="flex flex-col gap-4">
+				{filteredSchedules.length > 0 ? (
+					filteredSchedules.map((schedule) => (
+						<SprayScheduleCard
+							areaDescription={schedule.area_description}
+							endTime={schedule.end_time}
+							insecticideLabelUrl={schedule.insecticideLabelUrl}
+							insecticideMsdsUrl={schedule.insecticideMsdsUrl}
+							insecticideName={schedule.insecticideName}
+							key={schedule.id}
+							mapUrl={schedule.map_url}
+							missionDate={schedule.mission_date}
+							municipalities={schedule.municipalities
+								.map((m) => m.name)
+								.sort()
+								.join(", ")}
+							rainDate={schedule.rain_date}
+							startTime={schedule.start_time}
+							status={schedule.status}
+						/>
+					))
+				) : (
+					<p className="py-8 text-center text-muted-foreground">
+						No spray missions found matching your filters.
+					</p>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/packages/supabase/src/collections/notices.ts
+++ b/packages/supabase/src/collections/notices.ts
@@ -42,6 +42,11 @@ import {
 	MosquitofishRequestsUpdateSchema,
 } from "../db/mosquitofish-requests";
 import {
+	MunicipalitiesInsertSchema,
+	MunicipalitiesRowSchema,
+	MunicipalitiesUpdateSchema,
+} from "../db/municipalities";
+import {
 	NoticeTypesInsertSchema,
 	NoticeTypesRowSchema,
 	NoticeTypesUpdateSchema,
@@ -51,6 +56,11 @@ import {
 	NoticesRowSchema,
 	NoticesUpdateSchema,
 } from "../db/notices";
+import {
+	SpraySchedulesInsertSchema,
+	SpraySchedulesRowSchema,
+	SpraySchedulesUpdateSchema,
+} from "../db/spray-schedules";
 import {
 	WaterManagementRequestsBaseSchema,
 	WaterManagementRequestsInsertSchema,
@@ -181,6 +191,25 @@ export function createNoticesCollections({
 		updateSchema: ContactFormSubmissionsUpdateSchema,
 	});
 
+	const municipalities = createEagerCollection({
+		insertSchema: MunicipalitiesInsertSchema,
+		queryClient,
+		schema: MunicipalitiesRowSchema,
+		supabase,
+		table: "municipalities",
+		updateSchema: MunicipalitiesUpdateSchema,
+	});
+
+	const spraySchedules = createEagerCollection({
+		allowDelete: true,
+		insertSchema: SpraySchedulesInsertSchema,
+		queryClient,
+		schema: SpraySchedulesRowSchema,
+		supabase,
+		table: "spray_schedules",
+		updateSchema: SpraySchedulesUpdateSchema,
+	});
+
 	return {
 		adultMosquitoRequests,
 		contactFormSubmissions,
@@ -190,8 +219,10 @@ export function createNoticesCollections({
 		insecticides,
 		meetings,
 		mosquitofishRequests,
+		municipalities,
 		noticeTypes,
 		notices,
+		spraySchedules,
 		waterManagementRequests,
 		zipCodes,
 	};

--- a/packages/supabase/src/database.types.ts
+++ b/packages/supabase/src/database.types.ts
@@ -451,6 +451,33 @@ export type Database = {
 					},
 				];
 			};
+			municipalities: {
+				Row: {
+					created_at: string;
+					created_by: string | null;
+					id: string;
+					name: string;
+					updated_at: string;
+					updated_by: string | null;
+				};
+				Insert: {
+					created_at?: string;
+					created_by?: string | null;
+					id?: string;
+					name: string;
+					updated_at?: string;
+					updated_by?: string | null;
+				};
+				Update: {
+					created_at?: string;
+					created_by?: string | null;
+					id?: string;
+					name?: string;
+					updated_at?: string;
+					updated_by?: string | null;
+				};
+				Relationships: [];
+			};
 			notice_types: {
 				Row: {
 					created_at: string;
@@ -551,6 +578,92 @@ export type Database = {
 					permission_name?: string;
 				};
 				Relationships: [];
+			};
+			spray_schedule_municipalities: {
+				Row: {
+					municipality_id: string;
+					spray_schedule_id: string;
+				};
+				Insert: {
+					municipality_id: string;
+					spray_schedule_id: string;
+				};
+				Update: {
+					municipality_id?: string;
+					spray_schedule_id?: string;
+				};
+				Relationships: [
+					{
+						foreignKeyName: "spray_schedule_municipalities_municipality_id_fkey";
+						columns: ["municipality_id"];
+						isOneToOne: false;
+						referencedRelation: "municipalities";
+						referencedColumns: ["id"];
+					},
+					{
+						foreignKeyName: "spray_schedule_municipalities_spray_schedule_id_fkey";
+						columns: ["spray_schedule_id"];
+						isOneToOne: false;
+						referencedRelation: "spray_schedules";
+						referencedColumns: ["id"];
+					},
+				];
+			};
+			spray_schedules: {
+				Row: {
+					area_description: string;
+					created_at: string;
+					created_by: string | null;
+					end_time: string;
+					id: string;
+					insecticide_id: string;
+					map_url: string | null;
+					mission_date: string;
+					rain_date: string | null;
+					start_time: string;
+					status: Database["public"]["Enums"]["spray_schedule_status"];
+					updated_at: string;
+					updated_by: string | null;
+				};
+				Insert: {
+					area_description: string;
+					created_at?: string;
+					created_by?: string | null;
+					end_time: string;
+					id?: string;
+					insecticide_id: string;
+					map_url?: string | null;
+					mission_date: string;
+					rain_date?: string | null;
+					start_time: string;
+					status?: Database["public"]["Enums"]["spray_schedule_status"];
+					updated_at?: string;
+					updated_by?: string | null;
+				};
+				Update: {
+					area_description?: string;
+					created_at?: string;
+					created_by?: string | null;
+					end_time?: string;
+					id?: string;
+					insecticide_id?: string;
+					map_url?: string | null;
+					mission_date?: string;
+					rain_date?: string | null;
+					start_time?: string;
+					status?: Database["public"]["Enums"]["spray_schedule_status"];
+					updated_at?: string;
+					updated_by?: string | null;
+				};
+				Relationships: [
+					{
+						foreignKeyName: "spray_schedules_insecticide_id_fkey";
+						columns: ["insecticide_id"];
+						isOneToOne: false;
+						referencedRelation: "insecticides";
+						referencedColumns: ["id"];
+					},
+				];
 			};
 			user_permissions: {
 				Row: {
@@ -699,7 +812,11 @@ export type Database = {
 			has_permission: { Args: { p_permission_name: string }; Returns: boolean };
 		};
 		Enums: {
-			[_ in never]: never;
+			spray_schedule_status:
+				| "scheduled"
+				| "delayed"
+				| "cancelled"
+				| "completed";
 		};
 		CompositeTypes: {
 			[_ in never]: never;
@@ -832,6 +949,8 @@ export const Constants = {
 		Enums: {},
 	},
 	public: {
-		Enums: {},
+		Enums: {
+			spray_schedule_status: ["scheduled", "delayed", "cancelled", "completed"],
+		},
 	},
 } as const;

--- a/packages/supabase/src/db/municipalities.ts
+++ b/packages/supabase/src/db/municipalities.ts
@@ -1,0 +1,27 @@
+import z from "zod";
+
+export const MunicipalitiesRowSchema = z.object({
+	created_at: z.coerce.date<Date>(),
+	created_by: z.string().nullable(),
+	id: z.uuid(),
+	name: z.string(),
+	updated_at: z.coerce.date<Date>(),
+	updated_by: z.string().nullable(),
+});
+
+export const MunicipalitiesInsertSchema = z.object({
+	id: z.uuid(),
+	name: z.string(),
+});
+
+export const MunicipalitiesUpdateSchema = z.object({
+	name: z.string().optional(),
+});
+
+export type MunicipalitiesRowType = z.infer<typeof MunicipalitiesRowSchema>;
+export type MunicipalitiesInsertType = z.infer<
+	typeof MunicipalitiesInsertSchema
+>;
+export type MunicipalitiesUpdateType = z.infer<
+	typeof MunicipalitiesUpdateSchema
+>;

--- a/packages/supabase/src/db/spray-schedule-municipalities.ts
+++ b/packages/supabase/src/db/spray-schedule-municipalities.ts
@@ -1,0 +1,18 @@
+import z from "zod";
+
+export const SprayScheduleMunicipalitiesRowSchema = z.object({
+	municipality_id: z.uuid(),
+	spray_schedule_id: z.uuid(),
+});
+
+export const SprayScheduleMunicipalitiesInsertSchema = z.object({
+	municipality_id: z.uuid(),
+	spray_schedule_id: z.uuid(),
+});
+
+export type SprayScheduleMunicipalitiesRowType = z.infer<
+	typeof SprayScheduleMunicipalitiesRowSchema
+>;
+export type SprayScheduleMunicipalitiesInsertType = z.infer<
+	typeof SprayScheduleMunicipalitiesInsertSchema
+>;

--- a/packages/supabase/src/db/spray-schedules.ts
+++ b/packages/supabase/src/db/spray-schedules.ts
@@ -1,0 +1,68 @@
+import z from "zod";
+
+export const SprayScheduleStatusEnum = z.enum([
+	"scheduled",
+	"delayed",
+	"cancelled",
+	"completed",
+]);
+
+export type SprayScheduleStatus = z.infer<typeof SprayScheduleStatusEnum>;
+
+export const SpraySchedulesRowSchema = z.object({
+	area_description: z.string(),
+	created_at: z.coerce.date<Date>(),
+	created_by: z.string().nullable(),
+	end_time: z.string(),
+	id: z.uuid(),
+	insecticide_id: z.uuid(),
+	map_url: z.url().nullable(),
+	mission_date: z.coerce.date<Date>(),
+	rain_date: z.coerce.date<Date>().nullable(),
+	start_time: z.string(),
+	status: SprayScheduleStatusEnum,
+	updated_at: z.coerce.date<Date>(),
+	updated_by: z.string().nullable(),
+});
+
+export const SpraySchedulesInsertSchema = z.object({
+	area_description: z.string(),
+	end_time: z.string(),
+	id: z.uuid(),
+	insecticide_id: z.uuid(),
+	map_url: z.url().nullable().optional(),
+	mission_date: z.coerce.date<Date>().transform((date) => date.toISOString()),
+	rain_date: z.coerce
+		.date<Date>()
+		.nullable()
+		.optional()
+		.transform((date) => (date ? date.toISOString() : date)),
+	start_time: z.string(),
+	status: SprayScheduleStatusEnum,
+});
+
+export const SpraySchedulesUpdateSchema = z.object({
+	area_description: z.string().optional(),
+	end_time: z.string().optional(),
+	insecticide_id: z.uuid().optional(),
+	map_url: z.url().nullable().optional(),
+	mission_date: z.coerce
+		.date()
+		.optional()
+		.transform((date) => (date ? date.toISOString() : date)),
+	rain_date: z.coerce
+		.date()
+		.nullable()
+		.optional()
+		.transform((date) => (date ? date.toISOString() : date)),
+	start_time: z.string().optional(),
+	status: SprayScheduleStatusEnum.optional(),
+});
+
+export type SpraySchedulesRowType = z.infer<typeof SpraySchedulesRowSchema>;
+export type SpraySchedulesInsertType = z.infer<
+	typeof SpraySchedulesInsertSchema
+>;
+export type SpraySchedulesUpdateType = z.infer<
+	typeof SpraySchedulesUpdateSchema
+>;

--- a/packages/ui/src/forms/form-context.ts
+++ b/packages/ui/src/forms/form-context.ts
@@ -5,6 +5,7 @@ import { ComboboxField } from "./combobox-field";
 import { ContentField } from "./content-field";
 import { DateTimeField } from "./datetime-field";
 import { FormWrapper } from "./form-wrapper";
+import { MultiComboboxField } from "./multi-combobox-field";
 import { PasswordField } from "./password-field";
 import { PhoneField } from "./phone-field";
 import { ResetFormButton } from "./reset-form-button";
@@ -12,6 +13,7 @@ import { SubmitFormButton } from "./submit-form-button";
 import { SwitchField } from "./switch-field";
 import { TextField } from "./text-field";
 import { TextAreaField } from "./textarea-field";
+import { TimeField } from "./time-field";
 
 export const { fieldContext, formContext, useFieldContext, useFormContext } =
 	createFormHookContexts();
@@ -23,11 +25,13 @@ export const { useAppForm, withFieldGroup } = createFormHook({
 		ComboboxField,
 		ContentField,
 		DateTimeField,
+		MultiComboboxField,
 		PasswordField,
 		PhoneField,
 		SwitchField,
 		TextAreaField,
 		TextField,
+		TimeField,
 	},
 	fieldContext,
 	formComponents: { FormWrapper, ResetFormButton, SubmitFormButton },

--- a/packages/ui/src/forms/multi-combobox-field.tsx
+++ b/packages/ui/src/forms/multi-combobox-field.tsx
@@ -1,0 +1,38 @@
+import { FormField } from "../blocks/form-field";
+import { MultiComboboxInput } from "../inputs/multi-combobox-input";
+import { useFieldContext } from "./form-context";
+
+export function MultiComboboxField({
+	options,
+	placeholder,
+	searchPlaceholder,
+	emptyMessage,
+	...formFieldProps
+}: Omit<
+	React.ComponentPropsWithRef<typeof FormField>,
+	"children" | "errors" | "htmlFor" | "data-invalid"
+> &
+	Pick<
+		React.ComponentPropsWithRef<typeof MultiComboboxInput>,
+		"options" | "placeholder" | "searchPlaceholder" | "emptyMessage"
+	>) {
+	const field = useFieldContext<string[]>();
+	return (
+		<FormField
+			data-invalid={!field.state.meta.isValid}
+			errors={field.state.meta.errors}
+			htmlFor={field.name}
+			{...formFieldProps}
+		>
+			<MultiComboboxInput
+				disabled={field.state.meta.isValidating}
+				emptyMessage={emptyMessage}
+				onChange={(value) => field.handleChange(value)}
+				options={options}
+				placeholder={placeholder}
+				searchPlaceholder={searchPlaceholder}
+				value={field.state.value}
+			/>
+		</FormField>
+	);
+}

--- a/packages/ui/src/forms/time-field.tsx
+++ b/packages/ui/src/forms/time-field.tsx
@@ -1,0 +1,29 @@
+import { FormField } from "../blocks/form-field";
+import { TimeInput } from "../inputs/time-input";
+import { useFieldContext } from "./form-context";
+
+export function TimeField(
+	formFieldProps: Omit<
+		React.ComponentPropsWithRef<typeof FormField>,
+		"children" | "errors" | "htmlFor" | "data-invalid"
+	>,
+) {
+	const field = useFieldContext<string>();
+	return (
+		<FormField
+			data-invalid={!field.state.meta.isValid}
+			errors={field.state.meta.errors}
+			htmlFor={field.name}
+			{...formFieldProps}
+		>
+			<TimeInput
+				aria-invalid={!field.state.meta.isValid}
+				id={field.name}
+				name={field.name}
+				onBlur={field.handleBlur}
+				onChange={(e) => field.handleChange(e.target.value)}
+				value={field.state.value ?? ""}
+			/>
+		</FormField>
+	);
+}

--- a/packages/ui/src/inputs/multi-combobox-input.tsx
+++ b/packages/ui/src/inputs/multi-combobox-input.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { Check, ChevronsUpDown, X } from "lucide-react";
+import * as React from "react";
+import { Badge } from "../components/badge";
+import { Button } from "../components/button";
+import {
+	Command,
+	CommandEmpty,
+	CommandGroup,
+	CommandInput,
+	CommandItem,
+	CommandList,
+} from "../components/command";
+import { Popover, PopoverContent, PopoverTrigger } from "../components/popover";
+import { cn } from "../lib/utils";
+
+export interface MultiComboboxOption {
+	value: string;
+	label: string;
+}
+
+interface MultiComboboxInputProps {
+	options: MultiComboboxOption[];
+	value?: string[];
+	onChange?: (value: string[]) => void;
+	placeholder?: string;
+	searchPlaceholder?: string;
+	emptyMessage?: string;
+	className?: string;
+	disabled?: boolean;
+}
+
+export function MultiComboboxInput({
+	options,
+	value = [],
+	onChange,
+	placeholder = "Select options...",
+	searchPlaceholder = "Search...",
+	emptyMessage = "No option found.",
+	className,
+	disabled = false,
+}: MultiComboboxInputProps) {
+	const [open, setOpen] = React.useState(false);
+
+	const selectedLabels = value
+		.map((v) => options.find((o) => o.value === v)?.label)
+		.filter(Boolean);
+
+	function handleToggle(optionValue: string) {
+		const next = value.includes(optionValue)
+			? value.filter((v) => v !== optionValue)
+			: [...value, optionValue];
+		onChange?.(next);
+	}
+
+	function handleRemove(optionValue: string) {
+		onChange?.(value.filter((v) => v !== optionValue));
+	}
+
+	return (
+		<div className="flex flex-col gap-2">
+			<Popover onOpenChange={setOpen} open={open}>
+				<PopoverTrigger asChild>
+					<Button
+						aria-expanded={open}
+						className={cn("w-full justify-between", className)}
+						disabled={disabled}
+						role="combobox"
+						variant="outline"
+					>
+						{value.length > 0 ? `${value.length} selected` : placeholder}
+						<ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+					</Button>
+				</PopoverTrigger>
+				<PopoverContent align="start" className="w-full p-0">
+					<Command>
+						<CommandInput className="h-9" placeholder={searchPlaceholder} />
+						<CommandList>
+							<CommandEmpty>{emptyMessage}</CommandEmpty>
+							<CommandGroup>
+								{options.map((option) => (
+									<CommandItem
+										key={option.value}
+										onSelect={() => handleToggle(option.value)}
+										value={option.value}
+									>
+										{option.label}
+										<Check
+											className={cn(
+												"ml-auto h-4 w-4",
+												value.includes(option.value)
+													? "opacity-100"
+													: "opacity-0",
+											)}
+										/>
+									</CommandItem>
+								))}
+							</CommandGroup>
+						</CommandList>
+					</Command>
+				</PopoverContent>
+			</Popover>
+			{selectedLabels.length > 0 && (
+				<div className="flex flex-wrap gap-1">
+					{value.map((v) => {
+						const label = options.find((o) => o.value === v)?.label;
+						return (
+							<Badge key={v} variant="secondary">
+								{label}
+								<button
+									aria-label={`Remove ${label}`}
+									className="ml-1 rounded-full outline-none ring-offset-background focus:ring-2 focus:ring-ring focus:ring-offset-2"
+									onClick={() => handleRemove(v)}
+									type="button"
+								>
+									<X className="h-3 w-3" />
+								</button>
+							</Badge>
+						);
+					})}
+				</div>
+			)}
+		</div>
+	);
+}

--- a/packages/ui/src/inputs/time-input.tsx
+++ b/packages/ui/src/inputs/time-input.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { InputGroup, InputGroupInput } from "../components/input-group";
+
+interface TimeInputProps {
+	className?: string;
+}
+
+export function TimeInput({
+	className,
+	ref,
+	...props
+}: TimeInputProps & React.ComponentPropsWithRef<"input">) {
+	return (
+		<InputGroup className={className}>
+			<InputGroupInput ref={ref} type="time" {...props} />
+		</InputGroup>
+	);
+}

--- a/supabase/migrations/20260406000000_add_spray_schedules.sql
+++ b/supabase/migrations/20260406000000_add_spray_schedules.sql
@@ -1,0 +1,157 @@
+-- Spray schedule status enum
+
+create type spray_schedule_status as enum ('scheduled', 'delayed', 'cancelled', 'completed');
+
+-- Municipalities lookup table (seeded, not admin-managed)
+
+create table public.municipalities(
+    id uuid primary key default gen_random_uuid(),
+    name text not null unique,
+    created_at timestamptz not null default now(),
+    created_by uuid references auth.users(id) on delete set null,
+    updated_at timestamptz not null default now(),
+    updated_by uuid references auth.users(id) on delete set null
+);
+
+alter table public.municipalities enable row level security;
+
+create policy "select: allow all"
+on public.municipalities
+for select
+to public
+using (true);
+
+create policy "insert: public_notices permission"
+on public.municipalities
+for insert
+to authenticated
+with check (
+    has_permission('public_notices')
+);
+
+create policy "update: public_notices permission"
+on public.municipalities
+for update
+to authenticated
+using (
+    has_permission('public_notices')
+)
+with check (
+    has_permission('public_notices')
+);
+
+create policy "delete: public_notices permission"
+on public.municipalities
+for delete
+to authenticated
+using (
+    has_permission('public_notices')
+);
+
+create trigger updated_municipalities
+    before update or insert
+    on public.municipalities
+    for each row
+    execute function public.set_audit_fields();
+
+-- Spray schedules table
+
+create table public.spray_schedules(
+    id uuid primary key default gen_random_uuid(),
+    mission_date date not null,
+    start_time time not null,
+    end_time time not null,
+    rain_date date,
+    area_description text not null,
+    map_url text,
+    status spray_schedule_status not null default 'scheduled',
+    insecticide_id uuid not null references public.insecticides(id) on delete restrict,
+    created_at timestamptz not null default now(),
+    created_by uuid references auth.users(id) on delete set null,
+    updated_at timestamptz not null default now(),
+    updated_by uuid references auth.users(id) on delete set null
+);
+
+alter table public.spray_schedules enable row level security;
+
+create policy "select: allow all"
+on public.spray_schedules
+for select
+to public
+using (true);
+
+create policy "insert: public_notices permission"
+on public.spray_schedules
+for insert
+to authenticated
+with check (
+    has_permission('public_notices')
+);
+
+create policy "update: public_notices permission"
+on public.spray_schedules
+for update
+to authenticated
+using (
+    has_permission('public_notices')
+)
+with check (
+    has_permission('public_notices')
+);
+
+create policy "delete: public_notices permission"
+on public.spray_schedules
+for delete
+to authenticated
+using (
+    has_permission('public_notices')
+);
+
+create trigger updated_spray_schedules
+    before update or insert
+    on public.spray_schedules
+    for each row
+    execute function public.set_audit_fields();
+
+-- Spray schedule ↔ municipalities join table
+
+create table public.spray_schedule_municipalities(
+    spray_schedule_id uuid not null references public.spray_schedules(id) on delete cascade,
+    municipality_id uuid not null references public.municipalities(id) on delete restrict,
+    primary key (spray_schedule_id, municipality_id)
+);
+
+alter table public.spray_schedule_municipalities enable row level security;
+
+create policy "select: allow all"
+on public.spray_schedule_municipalities
+for select
+to public
+using (true);
+
+create policy "insert: public_notices permission"
+on public.spray_schedule_municipalities
+for insert
+to authenticated
+with check (
+    has_permission('public_notices')
+);
+
+create policy "update: public_notices permission"
+on public.spray_schedule_municipalities
+for update
+to authenticated
+using (
+    has_permission('public_notices')
+)
+with check (
+    has_permission('public_notices')
+);
+
+create policy "delete: public_notices permission"
+on public.spray_schedule_municipalities
+for delete
+to authenticated
+using (
+    has_permission('public_notices')
+);

--- a/supabase/schemas/200 - public notices/900 - spray_schedules.sql
+++ b/supabase/schemas/200 - public notices/900 - spray_schedules.sql
@@ -1,0 +1,165 @@
+-- =============================================================================
+-- Spray schedule status enum
+-- =============================================================================
+
+create type spray_schedule_status as enum ('scheduled', 'delayed', 'cancelled', 'completed');
+
+-- =============================================================================
+-- Municipalities lookup table (seeded, not admin-managed)
+-- =============================================================================
+
+create table public.municipalities(
+    id uuid primary key default gen_random_uuid(),
+    name text not null unique,
+    created_at timestamptz not null default now(),
+    created_by uuid references auth.users(id) on delete set null,
+    updated_at timestamptz not null default now(),
+    updated_by uuid references auth.users(id) on delete set null
+);
+
+alter table public.municipalities enable row level security;
+
+create policy "select: allow all"
+on public.municipalities
+for select
+to public
+using (true);
+
+create policy "insert: public_notices permission"
+on public.municipalities
+for insert
+to authenticated
+with check (
+    has_permission('public_notices')
+);
+
+create policy "update: public_notices permission"
+on public.municipalities
+for update
+to authenticated
+using (
+    has_permission('public_notices')
+)
+with check (
+    has_permission('public_notices')
+);
+
+create policy "delete: public_notices permission"
+on public.municipalities
+for delete
+to authenticated
+using (
+    has_permission('public_notices')
+);
+
+create trigger updated_municipalities
+    before update or insert
+    on public.municipalities
+    for each row
+    execute function public.set_audit_fields();
+
+-- =============================================================================
+-- Spray schedules table
+-- =============================================================================
+
+create table public.spray_schedules(
+    id uuid primary key default gen_random_uuid(),
+    mission_date date not null,
+    start_time time not null,
+    end_time time not null,
+    rain_date date,
+    area_description text not null,
+    map_url text,
+    status spray_schedule_status not null default 'scheduled',
+    insecticide_id uuid not null references public.insecticides(id) on delete restrict,
+    created_at timestamptz not null default now(),
+    created_by uuid references auth.users(id) on delete set null,
+    updated_at timestamptz not null default now(),
+    updated_by uuid references auth.users(id) on delete set null
+);
+
+alter table public.spray_schedules enable row level security;
+
+create policy "select: allow all"
+on public.spray_schedules
+for select
+to public
+using (true);
+
+create policy "insert: public_notices permission"
+on public.spray_schedules
+for insert
+to authenticated
+with check (
+    has_permission('public_notices')
+);
+
+create policy "update: public_notices permission"
+on public.spray_schedules
+for update
+to authenticated
+using (
+    has_permission('public_notices')
+)
+with check (
+    has_permission('public_notices')
+);
+
+create policy "delete: public_notices permission"
+on public.spray_schedules
+for delete
+to authenticated
+using (
+    has_permission('public_notices')
+);
+
+create trigger updated_spray_schedules
+    before update or insert
+    on public.spray_schedules
+    for each row
+    execute function public.set_audit_fields();
+
+-- =============================================================================
+-- Spray schedule ↔ municipalities join table
+-- =============================================================================
+
+create table public.spray_schedule_municipalities(
+    spray_schedule_id uuid not null references public.spray_schedules(id) on delete cascade,
+    municipality_id uuid not null references public.municipalities(id) on delete restrict,
+    primary key (spray_schedule_id, municipality_id)
+);
+
+alter table public.spray_schedule_municipalities enable row level security;
+
+create policy "select: allow all"
+on public.spray_schedule_municipalities
+for select
+to public
+using (true);
+
+create policy "insert: public_notices permission"
+on public.spray_schedule_municipalities
+for insert
+to authenticated
+with check (
+    has_permission('public_notices')
+);
+
+create policy "update: public_notices permission"
+on public.spray_schedule_municipalities
+for update
+to authenticated
+using (
+    has_permission('public_notices')
+)
+with check (
+    has_permission('public_notices')
+);
+
+create policy "delete: public_notices permission"
+on public.spray_schedule_municipalities
+for delete
+to authenticated
+using (
+    has_permission('public_notices')
+);

--- a/supabase/scripts/generate-seed.ts
+++ b/supabase/scripts/generate-seed.ts
@@ -127,6 +127,34 @@ const NOTICE_TYPES = [
 	{ name: "Advisory", description: "Public health advisories" },
 ];
 
+const MUNICIPALITIES = [
+	"Carteret",
+	"Cranbury",
+	"Dunellen",
+	"East Brunswick",
+	"Edison",
+	"Helmetta",
+	"Highland Park",
+	"Jamesburg",
+	"Metuchen",
+	"Middlesex Borough",
+	"Milltown",
+	"Monroe",
+	"New Brunswick",
+	"North Brunswick",
+	"Old Bridge",
+	"Perth Amboy",
+	"Piscataway",
+	"Plainsboro",
+	"Sayreville",
+	"South Amboy",
+	"South Brunswick",
+	"South Plainfield",
+	"South River",
+	"Spotswood",
+	"Woodbridge",
+];
+
 const ZIP_CODES = [
 	{ code: "08901", city: "New Brunswick", state: "NJ" },
 	{ code: "08902", city: "North Brunswick", state: "NJ" },
@@ -457,9 +485,90 @@ async function main() {
 	if (waterError)
 		throw new Error(`Failed to create water request: ${waterError.message}`);
 
+	// 11. Create municipalities
+	console.log("11. Creating municipalities...");
+	const { error: muniError } = await supabase
+		.from("municipalities")
+		.insert(MUNICIPALITIES.map((name) => ({ name })));
+	if (muniError)
+		throw new Error(`Failed to create municipalities: ${muniError.message}`);
+
+	// 12. Create sample spray schedules
+	console.log("12. Creating spray schedules...");
+	const { data: insecticideData } = await supabase
+		.from("insecticides")
+		.select("id, trade_name");
+	const insecticideMap = Object.fromEntries(
+		(insecticideData ?? []).map((i) => [i.trade_name, i.id]),
+	);
+
+	const { data: muniData } = await supabase
+		.from("municipalities")
+		.select("id, name");
+	const muniMap = Object.fromEntries(
+		(muniData ?? []).map((m) => [m.name, m.id]),
+	);
+
+	const spraySchedules = [
+		{
+			mission_date: "2026-04-10",
+			start_time: "19:00",
+			end_time: "23:00",
+			rain_date: "2026-04-11",
+			area_description:
+				"North District — residential areas along Route 1 corridor",
+			status: "scheduled",
+			insecticide_id: insecticideMap["Anvil 10+10 ULV"],
+			municipalities: ["Edison", "Metuchen", "Highland Park"],
+		},
+		{
+			mission_date: "2026-04-15",
+			start_time: "20:00",
+			end_time: "23:30",
+			area_description: "South District — wetland buffer zones and parks",
+			status: "scheduled",
+			insecticide_id: insecticideMap["Anvil 10+10 ULV"],
+			municipalities: ["Old Bridge", "Sayreville", "South Amboy"],
+		},
+		{
+			mission_date: "2026-03-25",
+			start_time: "19:30",
+			end_time: "22:30",
+			area_description:
+				"Central District — downtown and surrounding neighborhoods",
+			map_url: "https://maps.example.com/spray-central",
+			status: "completed",
+			insecticide_id: insecticideMap["Anvil 10+10 ULV"],
+			municipalities: ["New Brunswick", "North Brunswick"],
+		},
+	];
+
+	for (const schedule of spraySchedules) {
+		const { municipalities: muniNames, ...scheduleData } = schedule;
+		const { data: inserted, error: schedError } = await supabase
+			.from("spray_schedules")
+			.insert(scheduleData)
+			.select("id")
+			.single();
+		if (schedError)
+			throw new Error(`Failed to create spray schedule: ${schedError.message}`);
+
+		const joinRows = muniNames.map((name) => ({
+			spray_schedule_id: inserted.id,
+			municipality_id: muniMap[name],
+		}));
+		const { error: joinError } = await supabase
+			.from("spray_schedule_municipalities")
+			.insert(joinRows);
+		if (joinError)
+			throw new Error(
+				`Failed to link municipalities to spray schedule: ${joinError.message}`,
+			);
+	}
+
 	console.log("\n=== All seed data created ===\n");
 
-	// 11. Dump the database
+	// 13. Dump the database
 	console.log("Dumping database...");
 	// Use docker exec to run pg_dump inside the Supabase postgres container
 	// Only dump auth and public schemas — exclude all Supabase internal schemas

--- a/supabase/seeds/001_seed.sql
+++ b/supabase/seeds/001_seed.sql
@@ -32,24 +32,24 @@ SET row_security = off;
 -- Data for Name: users; Type: TABLE DATA; Schema: auth; Owner: -
 --
 
-INSERT INTO auth.users VALUES ('00000000-0000-0000-0000-000000000000', '1ff11e3f-c362-4ebd-a4b9-df695499d705', 'authenticated', 'authenticated', 'ljones@test.local', '$2a$10$pf1lleo5AAzT1PuKGaVtd..ZYnCRrLktin0czOJ6CKjA2XiUKHz3u', '2026-03-27 19:58:57.841226+00', NULL, '', NULL, '', NULL, '', '', NULL, NULL, '{"provider": "email", "providers": ["email"], "employee_id": "a041e97f-f5b6-4c69-a927-d1660386051c", "permissions": ["public_notices", "manage_employees", "admin_rights"]}', '{"email_verified": true}', NULL, '2026-03-27 19:58:57.834348+00', '2026-03-27 19:58:57.986959+00', NULL, NULL, '', '', NULL, DEFAULT, '', 0, NULL, '', NULL, false, NULL, false);
-INSERT INTO auth.users VALUES ('00000000-0000-0000-0000-000000000000', '7facae9c-e3ee-4b81-8b9b-06c8fb6c04b7', 'authenticated', 'authenticated', 'dwilliams@test.local', '$2a$10$Kk/KpqLjpUPC8.n.97Kb7.iRN7HhERLtiV5nZhiRhnwJUpzYOZ6jm', '2026-03-27 19:58:57.962595+00', NULL, '', NULL, '', NULL, '', '', NULL, NULL, '{"provider": "email", "providers": ["email"], "employee_id": "6563b223-a3af-4926-aa43-af9604e04cba"}', '{"email_verified": true}', NULL, '2026-03-27 19:58:57.956293+00', '2026-03-27 19:58:57.97295+00', NULL, NULL, '', '', NULL, DEFAULT, '', 0, NULL, '', NULL, false, NULL, false);
-INSERT INTO auth.users VALUES ('00000000-0000-0000-0000-000000000000', '5e84a53d-0d00-4fe5-907c-68ef6654139b', 'authenticated', 'authenticated', 'admin@test.local', '$2a$10$615Tjepgc8xFO/QntP1Tw.timJskE.oTvv0dEdRZXmg.cSwriKf5.', '2026-03-27 19:58:57.340733+00', NULL, '', NULL, '', NULL, '', '', NULL, NULL, '{"provider": "email", "providers": ["email"], "employee_id": "4d69c0ec-4e28-4dfe-9d36-72c686d3c061", "permissions": ["public_notices", "manage_employees", "admin_rights"]}', '{"email_verified": true}', NULL, '2026-03-27 19:58:57.33183+00', '2026-03-27 19:58:57.986959+00', NULL, NULL, '', '', NULL, DEFAULT, '', 0, NULL, '', NULL, false, NULL, false);
-INSERT INTO auth.users VALUES ('00000000-0000-0000-0000-000000000000', '8909ebe2-629a-4953-b1ea-0d65161801ed', 'authenticated', 'authenticated', 'jsmith@test.local', '$2a$10$hfqlYjxddrM5ovv4lJGNEeIarWHVM3zusbKq8GXN49y9tsjDd.idW', '2026-03-27 19:58:57.469295+00', NULL, '', NULL, '', NULL, '', '', NULL, NULL, '{"provider": "email", "providers": ["email"], "employee_id": "14955551-5e25-4bbc-9af0-3154d87fda66", "permissions": ["public_notices"]}', '{"email_verified": true}', NULL, '2026-03-27 19:58:57.463841+00', '2026-03-27 19:58:57.986959+00', NULL, NULL, '', '', NULL, DEFAULT, '', 0, NULL, '', NULL, false, NULL, false);
-INSERT INTO auth.users VALUES ('00000000-0000-0000-0000-000000000000', '4c2e3879-7c32-4604-b150-9f03a9ba74ac', 'authenticated', 'authenticated', 'mgarcia@test.local', '$2a$10$odj7ofMH3Yhov3EajyuxWenevqduGa4XwQd34LS71voyjtcV8YSaq', '2026-03-27 19:58:57.597777+00', NULL, '', NULL, '', NULL, '', '', NULL, NULL, '{"provider": "email", "providers": ["email"], "employee_id": "d8c6d3b2-78bb-4afc-81a0-6da3e78111f9", "permissions": ["public_notices"]}', '{"email_verified": true}', NULL, '2026-03-27 19:58:57.591327+00', '2026-03-27 19:58:57.986959+00', NULL, NULL, '', '', NULL, DEFAULT, '', 0, NULL, '', NULL, false, NULL, false);
-INSERT INTO auth.users VALUES ('00000000-0000-0000-0000-000000000000', 'ea7f5520-fb2e-418e-8632-8defab46a834', 'authenticated', 'authenticated', 'rjohnson@test.local', '$2a$10$46EbcMZRcMjdD6YKtVcO1.Dj8lLj5.NTu2fVRmaX3wwMkb0eiEq4.', '2026-03-27 19:58:57.718918+00', NULL, '', NULL, '', NULL, '', '', NULL, NULL, '{"provider": "email", "providers": ["email"], "employee_id": "bbdb66e9-95c1-4889-8515-c610519c6f33", "permissions": ["public_notices", "manage_employees"]}', '{"email_verified": true}', NULL, '2026-03-27 19:58:57.712129+00', '2026-03-27 19:58:57.986959+00', NULL, NULL, '', '', NULL, DEFAULT, '', 0, NULL, '', NULL, false, NULL, false);
+INSERT INTO auth.users VALUES ('00000000-0000-0000-0000-000000000000', '1221874e-982e-4d6d-9c21-361bceec8e1b', 'authenticated', 'authenticated', 'ljones@test.local', '$2a$10$yxdnADT4cSGgJYmKux/AVOCzGo6qrr.7Jtt1sb9cFVcAiYJA.pSRS', '2026-04-06 16:00:13.770293+00', NULL, '', NULL, '', NULL, '', '', NULL, NULL, '{"provider": "email", "providers": ["email"], "employee_id": "9b04ba4f-2bb2-4606-b8c4-3108e5d475fb", "permissions": ["public_notices", "manage_employees", "admin_rights"]}', '{"email_verified": true}', NULL, '2026-04-06 16:00:13.764067+00', '2026-04-06 16:00:13.899963+00', NULL, NULL, '', '', NULL, DEFAULT, '', 0, NULL, '', NULL, false, NULL, false);
+INSERT INTO auth.users VALUES ('00000000-0000-0000-0000-000000000000', '65c7bfeb-382f-4290-8aad-d48b5d16be52', 'authenticated', 'authenticated', 'dwilliams@test.local', '$2a$10$pjUhDcEC6fsjYNdLp1688eRnyl7cgguCgpOSCHf3vBEnxj5KRp/hG', '2026-04-06 16:00:13.877618+00', NULL, '', NULL, '', NULL, '', '', NULL, NULL, '{"provider": "email", "providers": ["email"], "employee_id": "66108592-c943-4162-8a56-99b74c338926"}', '{"email_verified": true}', NULL, '2026-04-06 16:00:13.872693+00', '2026-04-06 16:00:13.887088+00', NULL, NULL, '', '', NULL, DEFAULT, '', 0, NULL, '', NULL, false, NULL, false);
+INSERT INTO auth.users VALUES ('00000000-0000-0000-0000-000000000000', 'c62f371a-d7f9-4979-acbf-5eaef2b06697', 'authenticated', 'authenticated', 'admin@test.local', '$2a$10$Tqoyr.clJgClSLDLEehWCeTZY.mbSYQ6sxQk307ifeOkNkIhq2i5C', '2026-04-06 16:00:13.329337+00', NULL, '', NULL, '', NULL, '', '', NULL, NULL, '{"provider": "email", "providers": ["email"], "employee_id": "4e4fafaf-09ea-414c-ab43-21158d49c530", "permissions": ["public_notices", "manage_employees", "admin_rights"]}', '{"email_verified": true}', NULL, '2026-04-06 16:00:13.321336+00', '2026-04-06 16:00:13.899963+00', NULL, NULL, '', '', NULL, DEFAULT, '', 0, NULL, '', NULL, false, NULL, false);
+INSERT INTO auth.users VALUES ('00000000-0000-0000-0000-000000000000', 'fe00b13e-0f88-483a-a206-2690d8650988', 'authenticated', 'authenticated', 'jsmith@test.local', '$2a$10$H6E.Bj/2PfQZ5n76mCuq/O/wTr47vJWM7OCBl/rOLGeq61ZriSpTi', '2026-04-06 16:00:13.445569+00', NULL, '', NULL, '', NULL, '', '', NULL, NULL, '{"provider": "email", "providers": ["email"], "employee_id": "26d17513-547f-450f-80a1-921f6c226417", "permissions": ["public_notices"]}', '{"email_verified": true}', NULL, '2026-04-06 16:00:13.440578+00', '2026-04-06 16:00:13.899963+00', NULL, NULL, '', '', NULL, DEFAULT, '', 0, NULL, '', NULL, false, NULL, false);
+INSERT INTO auth.users VALUES ('00000000-0000-0000-0000-000000000000', '2ef27411-6514-4b91-8a8e-f548be9cc723', 'authenticated', 'authenticated', 'mgarcia@test.local', '$2a$10$xwk4z9N0DgM7KiYlIo2jAetcJCmaMcOO.kuQs5qZ2EaSV6q.vqblC', '2026-04-06 16:00:13.554112+00', NULL, '', NULL, '', NULL, '', '', NULL, NULL, '{"provider": "email", "providers": ["email"], "employee_id": "3c7c21bd-64b0-443e-bc0b-ecf24e71a007", "permissions": ["public_notices"]}', '{"email_verified": true}', NULL, '2026-04-06 16:00:13.548259+00', '2026-04-06 16:00:13.899963+00', NULL, NULL, '', '', NULL, DEFAULT, '', 0, NULL, '', NULL, false, NULL, false);
+INSERT INTO auth.users VALUES ('00000000-0000-0000-0000-000000000000', '5fab3d2e-c474-47e6-9cb4-5db205e8a533', 'authenticated', 'authenticated', 'rjohnson@test.local', '$2a$10$GIw9PzPTb1rjbLr041S2ouGioodNqMBCAtjx3S5tSKL58vD2bewq.', '2026-04-06 16:00:13.659284+00', NULL, '', NULL, '', NULL, '', '', NULL, NULL, '{"provider": "email", "providers": ["email"], "employee_id": "6982f673-db2f-4448-b842-864bc546dbc7", "permissions": ["public_notices", "manage_employees"]}', '{"email_verified": true}', NULL, '2026-04-06 16:00:13.653977+00', '2026-04-06 16:00:13.899963+00', NULL, NULL, '', '', NULL, DEFAULT, '', 0, NULL, '', NULL, false, NULL, false);
 
 
 --
 -- Data for Name: identities; Type: TABLE DATA; Schema: auth; Owner: -
 --
 
-INSERT INTO auth.identities VALUES ('5e84a53d-0d00-4fe5-907c-68ef6654139b', '5e84a53d-0d00-4fe5-907c-68ef6654139b', '{"sub": "5e84a53d-0d00-4fe5-907c-68ef6654139b", "email": "admin@test.local", "email_verified": false, "phone_verified": false}', 'email', '2026-03-27 19:58:57.335938+00', '2026-03-27 19:58:57.335977+00', '2026-03-27 19:58:57.335977+00', DEFAULT, '88505709-45a6-4323-9e03-4000243095e6');
-INSERT INTO auth.identities VALUES ('8909ebe2-629a-4953-b1ea-0d65161801ed', '8909ebe2-629a-4953-b1ea-0d65161801ed', '{"sub": "8909ebe2-629a-4953-b1ea-0d65161801ed", "email": "jsmith@test.local", "email_verified": false, "phone_verified": false}', 'email', '2026-03-27 19:58:57.466049+00', '2026-03-27 19:58:57.466083+00', '2026-03-27 19:58:57.466083+00', DEFAULT, '645ea4fb-a8e3-4a07-928f-2585e6eb9b59');
-INSERT INTO auth.identities VALUES ('4c2e3879-7c32-4604-b150-9f03a9ba74ac', '4c2e3879-7c32-4604-b150-9f03a9ba74ac', '{"sub": "4c2e3879-7c32-4604-b150-9f03a9ba74ac", "email": "mgarcia@test.local", "email_verified": false, "phone_verified": false}', 'email', '2026-03-27 19:58:57.593702+00', '2026-03-27 19:58:57.593743+00', '2026-03-27 19:58:57.593743+00', DEFAULT, 'c5bf2be3-24ee-48e4-915f-1541a4c0934d');
-INSERT INTO auth.identities VALUES ('ea7f5520-fb2e-418e-8632-8defab46a834', 'ea7f5520-fb2e-418e-8632-8defab46a834', '{"sub": "ea7f5520-fb2e-418e-8632-8defab46a834", "email": "rjohnson@test.local", "email_verified": false, "phone_verified": false}', 'email', '2026-03-27 19:58:57.714908+00', '2026-03-27 19:58:57.714946+00', '2026-03-27 19:58:57.714946+00', DEFAULT, 'ec918ff1-ec46-4f69-80c3-ff14908b4147');
-INSERT INTO auth.identities VALUES ('1ff11e3f-c362-4ebd-a4b9-df695499d705', '1ff11e3f-c362-4ebd-a4b9-df695499d705', '{"sub": "1ff11e3f-c362-4ebd-a4b9-df695499d705", "email": "ljones@test.local", "email_verified": false, "phone_verified": false}', 'email', '2026-03-27 19:58:57.836805+00', '2026-03-27 19:58:57.836845+00', '2026-03-27 19:58:57.836845+00', DEFAULT, 'ee91e91a-606d-48eb-a873-0d85a6043c21');
-INSERT INTO auth.identities VALUES ('7facae9c-e3ee-4b81-8b9b-06c8fb6c04b7', '7facae9c-e3ee-4b81-8b9b-06c8fb6c04b7', '{"sub": "7facae9c-e3ee-4b81-8b9b-06c8fb6c04b7", "email": "dwilliams@test.local", "email_verified": false, "phone_verified": false}', 'email', '2026-03-27 19:58:57.958576+00', '2026-03-27 19:58:57.958616+00', '2026-03-27 19:58:57.958616+00', DEFAULT, '5d78a365-fc6e-4dbc-a086-0b4a5d77f12e');
+INSERT INTO auth.identities VALUES ('c62f371a-d7f9-4979-acbf-5eaef2b06697', 'c62f371a-d7f9-4979-acbf-5eaef2b06697', '{"sub": "c62f371a-d7f9-4979-acbf-5eaef2b06697", "email": "admin@test.local", "email_verified": false, "phone_verified": false}', 'email', '2026-04-06 16:00:13.325781+00', '2026-04-06 16:00:13.325819+00', '2026-04-06 16:00:13.325819+00', DEFAULT, '72f678c7-fa67-44e8-a9e6-0c196dc963a5');
+INSERT INTO auth.identities VALUES ('fe00b13e-0f88-483a-a206-2690d8650988', 'fe00b13e-0f88-483a-a206-2690d8650988', '{"sub": "fe00b13e-0f88-483a-a206-2690d8650988", "email": "jsmith@test.local", "email_verified": false, "phone_verified": false}', 'email', '2026-04-06 16:00:13.442509+00', '2026-04-06 16:00:13.442539+00', '2026-04-06 16:00:13.442539+00', DEFAULT, '79e52f41-6737-47c8-9dfc-f30327ae4f4d');
+INSERT INTO auth.identities VALUES ('2ef27411-6514-4b91-8a8e-f548be9cc723', '2ef27411-6514-4b91-8a8e-f548be9cc723', '{"sub": "2ef27411-6514-4b91-8a8e-f548be9cc723", "email": "mgarcia@test.local", "email_verified": false, "phone_verified": false}', 'email', '2026-04-06 16:00:13.550553+00', '2026-04-06 16:00:13.550586+00', '2026-04-06 16:00:13.550586+00', DEFAULT, '8ef87fa4-9e11-4374-a8cf-3c94848a219f');
+INSERT INTO auth.identities VALUES ('5fab3d2e-c474-47e6-9cb4-5db205e8a533', '5fab3d2e-c474-47e6-9cb4-5db205e8a533', '{"sub": "5fab3d2e-c474-47e6-9cb4-5db205e8a533", "email": "rjohnson@test.local", "email_verified": false, "phone_verified": false}', 'email', '2026-04-06 16:00:13.6559+00', '2026-04-06 16:00:13.655936+00', '2026-04-06 16:00:13.655936+00', DEFAULT, '6b6cc852-e8ae-48dd-93a6-92210a64c70d');
+INSERT INTO auth.identities VALUES ('1221874e-982e-4d6d-9c21-361bceec8e1b', '1221874e-982e-4d6d-9c21-361bceec8e1b', '{"sub": "1221874e-982e-4d6d-9c21-361bceec8e1b", "email": "ljones@test.local", "email_verified": false, "phone_verified": false}', 'email', '2026-04-06 16:00:13.766763+00', '2026-04-06 16:00:13.766859+00', '2026-04-06 16:00:13.766859+00', DEFAULT, '4dda9164-a92e-4c62-b5cb-67696f0f2741');
+INSERT INTO auth.identities VALUES ('65c7bfeb-382f-4290-8aad-d48b5d16be52', '65c7bfeb-382f-4290-8aad-d48b5d16be52', '{"sub": "65c7bfeb-382f-4290-8aad-d48b5d16be52", "email": "dwilliams@test.local", "email_verified": false, "phone_verified": false}', 'email', '2026-04-06 16:00:13.874563+00', '2026-04-06 16:00:13.874597+00', '2026-04-06 16:00:13.874597+00', DEFAULT, 'b78ee0ad-2344-4feb-ba3e-5d397e3a58b1');
 
 
 --
@@ -86,162 +86,224 @@ INSERT INTO auth.identities VALUES ('7facae9c-e3ee-4b81-8b9b-06c8fb6c04b7', '7fa
 -- Data for Name: zip_codes; Type: TABLE DATA; Schema: public; Owner: -
 --
 
-INSERT INTO public.zip_codes VALUES ('2c0ea4d2-0163-4792-9d28-d16d4c0bacf0', '08901', 'New Brunswick', 'NJ', '2026-03-27 19:58:58.032292+00', NULL, '2026-03-27 19:58:58.032292+00', NULL);
-INSERT INTO public.zip_codes VALUES ('6358865d-5ae7-46a6-a9f7-9c27c4518e1a', '08902', 'North Brunswick', 'NJ', '2026-03-27 19:58:58.032292+00', NULL, '2026-03-27 19:58:58.032292+00', NULL);
-INSERT INTO public.zip_codes VALUES ('843ba729-e6a2-4288-8085-ffa779623612', '08903', 'New Brunswick', 'NJ', '2026-03-27 19:58:58.032292+00', NULL, '2026-03-27 19:58:58.032292+00', NULL);
-INSERT INTO public.zip_codes VALUES ('a13c6cbd-b63d-487c-9a0c-f97b792dbebf', '08816', 'East Brunswick', 'NJ', '2026-03-27 19:58:58.032292+00', NULL, '2026-03-27 19:58:58.032292+00', NULL);
-INSERT INTO public.zip_codes VALUES ('27747c17-cbab-44cc-a477-2d7a149e0c91', '08817', 'Edison', 'NJ', '2026-03-27 19:58:58.032292+00', NULL, '2026-03-27 19:58:58.032292+00', NULL);
-INSERT INTO public.zip_codes VALUES ('7954b539-5360-4660-b04d-23af21bfa379', '08820', 'Edison', 'NJ', '2026-03-27 19:58:58.032292+00', NULL, '2026-03-27 19:58:58.032292+00', NULL);
-INSERT INTO public.zip_codes VALUES ('bf4a76a3-b5aa-4e8d-b3d8-ac81a94bba41', '08837', 'Edison', 'NJ', '2026-03-27 19:58:58.032292+00', NULL, '2026-03-27 19:58:58.032292+00', NULL);
-INSERT INTO public.zip_codes VALUES ('7ef7d377-f775-46af-bc97-2248a1651ea7', '08840', 'Metuchen', 'NJ', '2026-03-27 19:58:58.032292+00', NULL, '2026-03-27 19:58:58.032292+00', NULL);
-INSERT INTO public.zip_codes VALUES ('22dfb2b5-b5c3-41a1-943a-ddabd7bf808a', '08846', 'Middlesex', 'NJ', '2026-03-27 19:58:58.032292+00', NULL, '2026-03-27 19:58:58.032292+00', NULL);
-INSERT INTO public.zip_codes VALUES ('d334fbdc-38ca-41a6-8f50-01d669c6b10d', '08854', 'Piscataway', 'NJ', '2026-03-27 19:58:58.032292+00', NULL, '2026-03-27 19:58:58.032292+00', NULL);
-INSERT INTO public.zip_codes VALUES ('4dffe6a3-578a-4806-82a0-47175c5779c2', '08855', 'Piscataway', 'NJ', '2026-03-27 19:58:58.032292+00', NULL, '2026-03-27 19:58:58.032292+00', NULL);
-INSERT INTO public.zip_codes VALUES ('bf09ac56-d4ef-4362-8a96-60bffbaffe81', '08857', 'Old Bridge', 'NJ', '2026-03-27 19:58:58.032292+00', NULL, '2026-03-27 19:58:58.032292+00', NULL);
-INSERT INTO public.zip_codes VALUES ('a7dea869-4fcb-4ba5-9daa-81c7fc698a7b', '08859', 'Parlin', 'NJ', '2026-03-27 19:58:58.032292+00', NULL, '2026-03-27 19:58:58.032292+00', NULL);
-INSERT INTO public.zip_codes VALUES ('c884d506-c1dd-4444-9b08-293c6b051510', '08861', 'Perth Amboy', 'NJ', '2026-03-27 19:58:58.032292+00', NULL, '2026-03-27 19:58:58.032292+00', NULL);
-INSERT INTO public.zip_codes VALUES ('77409f0b-69ca-49f3-b723-b08b6a97e1b6', '08862', 'Perth Amboy', 'NJ', '2026-03-27 19:58:58.032292+00', NULL, '2026-03-27 19:58:58.032292+00', NULL);
-INSERT INTO public.zip_codes VALUES ('271a5a27-b856-42f8-a500-bfe8f74cdaa4', '08863', 'Fords', 'NJ', '2026-03-27 19:58:58.032292+00', NULL, '2026-03-27 19:58:58.032292+00', NULL);
-INSERT INTO public.zip_codes VALUES ('3eb9f3f8-4ad0-4825-bb99-2b67b9bf181c', '08871', 'Sayreville', 'NJ', '2026-03-27 19:58:58.032292+00', NULL, '2026-03-27 19:58:58.032292+00', NULL);
-INSERT INTO public.zip_codes VALUES ('3081b458-2873-4683-ba19-6f9712c2bf09', '08872', 'Sayreville', 'NJ', '2026-03-27 19:58:58.032292+00', NULL, '2026-03-27 19:58:58.032292+00', NULL);
-INSERT INTO public.zip_codes VALUES ('809eae79-3f64-41bd-adf9-44b90c9d2ec0', '08879', 'South Amboy', 'NJ', '2026-03-27 19:58:58.032292+00', NULL, '2026-03-27 19:58:58.032292+00', NULL);
-INSERT INTO public.zip_codes VALUES ('e61c2211-de71-4f26-b569-086011f66830', '08882', 'South River', 'NJ', '2026-03-27 19:58:58.032292+00', NULL, '2026-03-27 19:58:58.032292+00', NULL);
-INSERT INTO public.zip_codes VALUES ('110b00c5-fb11-4068-956f-98b3c2bad48b', '08884', 'Spotswood', 'NJ', '2026-03-27 19:58:58.032292+00', NULL, '2026-03-27 19:58:58.032292+00', NULL);
-INSERT INTO public.zip_codes VALUES ('469c458b-f1db-4d7a-b6ce-a4bdd64d54bf', '08899', 'Edison', 'NJ', '2026-03-27 19:58:58.032292+00', NULL, '2026-03-27 19:58:58.032292+00', NULL);
-INSERT INTO public.zip_codes VALUES ('e7dc10ef-d7d0-4f77-a5ad-1cd1172d6ab4', '07001', 'Avenel', 'NJ', '2026-03-27 19:58:58.032292+00', NULL, '2026-03-27 19:58:58.032292+00', NULL);
-INSERT INTO public.zip_codes VALUES ('54d43694-d185-498a-8314-fc2f756f7991', '07064', 'Port Reading', 'NJ', '2026-03-27 19:58:58.032292+00', NULL, '2026-03-27 19:58:58.032292+00', NULL);
-INSERT INTO public.zip_codes VALUES ('e6518b48-8e1d-458a-9aa1-61d9f984d7a7', '07067', 'Colonia', 'NJ', '2026-03-27 19:58:58.032292+00', NULL, '2026-03-27 19:58:58.032292+00', NULL);
-INSERT INTO public.zip_codes VALUES ('d645d815-8150-40c0-9f3e-dda82465979e', '07077', 'Sewaren', 'NJ', '2026-03-27 19:58:58.032292+00', NULL, '2026-03-27 19:58:58.032292+00', NULL);
-INSERT INTO public.zip_codes VALUES ('8ad8f313-6163-49a4-b1e6-e0627fc2a29d', '07080', 'South Plainfield', 'NJ', '2026-03-27 19:58:58.032292+00', NULL, '2026-03-27 19:58:58.032292+00', NULL);
-INSERT INTO public.zip_codes VALUES ('238b7bf7-a29c-45eb-8fed-75d26f36cb04', '07095', 'Woodbridge', 'NJ', '2026-03-27 19:58:58.032292+00', NULL, '2026-03-27 19:58:58.032292+00', NULL);
-INSERT INTO public.zip_codes VALUES ('90f424bc-6878-4e1b-a290-7c7a988d37d5', '08810', 'Dayton', 'NJ', '2026-03-27 19:58:58.032292+00', NULL, '2026-03-27 19:58:58.032292+00', NULL);
-INSERT INTO public.zip_codes VALUES ('41764a6c-0e0f-467e-b111-bb6b8d093247', '08812', 'Dunellen', 'NJ', '2026-03-27 19:58:58.032292+00', NULL, '2026-03-27 19:58:58.032292+00', NULL);
-INSERT INTO public.zip_codes VALUES ('8c12a56b-831f-40d7-8be4-1a628f0457fe', '08824', 'Kendall Park', 'NJ', '2026-03-27 19:58:58.032292+00', NULL, '2026-03-27 19:58:58.032292+00', NULL);
-INSERT INTO public.zip_codes VALUES ('722103a3-829e-4252-ba2e-337fbf106d9b', '08828', 'Helmetta', 'NJ', '2026-03-27 19:58:58.032292+00', NULL, '2026-03-27 19:58:58.032292+00', NULL);
-INSERT INTO public.zip_codes VALUES ('6adcff45-57f9-4605-82fe-d70b5ec4399a', '08830', 'Iselin', 'NJ', '2026-03-27 19:58:58.032292+00', NULL, '2026-03-27 19:58:58.032292+00', NULL);
-INSERT INTO public.zip_codes VALUES ('4898be27-a729-4026-b6e1-ec0d7c1b3c03', '08831', 'Monroe Township', 'NJ', '2026-03-27 19:58:58.032292+00', NULL, '2026-03-27 19:58:58.032292+00', NULL);
-INSERT INTO public.zip_codes VALUES ('6d836500-de46-4993-9631-fb6e57fd2a59', '08832', 'Jamesburg', 'NJ', '2026-03-27 19:58:58.032292+00', NULL, '2026-03-27 19:58:58.032292+00', NULL);
-INSERT INTO public.zip_codes VALUES ('884c73f3-99b4-4711-846a-6b043a6b3dbc', '08850', 'Milltown', 'NJ', '2026-03-27 19:58:58.032292+00', NULL, '2026-03-27 19:58:58.032292+00', NULL);
-INSERT INTO public.zip_codes VALUES ('e8b54d09-b55d-4d75-b0d3-00e15d720930', '08852', 'Monmouth Junction', 'NJ', '2026-03-27 19:58:58.032292+00', NULL, '2026-03-27 19:58:58.032292+00', NULL);
-INSERT INTO public.zip_codes VALUES ('9b1fb174-186f-4f82-afe7-61542439b3b1', '07008', 'Carteret', 'NJ', '2026-03-27 19:58:58.032292+00', NULL, '2026-03-27 19:58:58.032292+00', NULL);
-INSERT INTO public.zip_codes VALUES ('14a805e6-3a6e-45e0-8e0c-2f80e4d342ef', '08536', 'Plainsboro', 'NJ', '2026-03-27 19:58:58.032292+00', NULL, '2026-03-27 19:58:58.032292+00', NULL);
-INSERT INTO public.zip_codes VALUES ('00d25d55-9463-4b5d-aef1-7a199d18fadd', '08540', 'Princeton', 'NJ', '2026-03-27 19:58:58.032292+00', NULL, '2026-03-27 19:58:58.032292+00', NULL);
+INSERT INTO public.zip_codes VALUES ('2fc27ee6-7637-423a-95ec-9ad1e6da7917', '08901', 'New Brunswick', 'NJ', '2026-04-06 16:00:13.940833+00', NULL, '2026-04-06 16:00:13.940833+00', NULL);
+INSERT INTO public.zip_codes VALUES ('a32a25c8-a493-4f83-9aa6-ffdb586741c2', '08902', 'North Brunswick', 'NJ', '2026-04-06 16:00:13.940833+00', NULL, '2026-04-06 16:00:13.940833+00', NULL);
+INSERT INTO public.zip_codes VALUES ('477c634c-0742-4299-8378-fc4c0f234528', '08903', 'New Brunswick', 'NJ', '2026-04-06 16:00:13.940833+00', NULL, '2026-04-06 16:00:13.940833+00', NULL);
+INSERT INTO public.zip_codes VALUES ('04e63f00-2577-47ae-8656-8dbba1694ee8', '08816', 'East Brunswick', 'NJ', '2026-04-06 16:00:13.940833+00', NULL, '2026-04-06 16:00:13.940833+00', NULL);
+INSERT INTO public.zip_codes VALUES ('10faa487-9077-4103-85d9-6722a867d712', '08817', 'Edison', 'NJ', '2026-04-06 16:00:13.940833+00', NULL, '2026-04-06 16:00:13.940833+00', NULL);
+INSERT INTO public.zip_codes VALUES ('68af1c69-6410-4bca-befc-42bb20b19a38', '08820', 'Edison', 'NJ', '2026-04-06 16:00:13.940833+00', NULL, '2026-04-06 16:00:13.940833+00', NULL);
+INSERT INTO public.zip_codes VALUES ('6ab18e63-6841-4bd5-80a9-6a42b086f637', '08837', 'Edison', 'NJ', '2026-04-06 16:00:13.940833+00', NULL, '2026-04-06 16:00:13.940833+00', NULL);
+INSERT INTO public.zip_codes VALUES ('27699a3f-3fca-4351-9c75-2dca9c941098', '08840', 'Metuchen', 'NJ', '2026-04-06 16:00:13.940833+00', NULL, '2026-04-06 16:00:13.940833+00', NULL);
+INSERT INTO public.zip_codes VALUES ('995d4e50-2166-417b-a03d-3cf7291a6bd0', '08846', 'Middlesex', 'NJ', '2026-04-06 16:00:13.940833+00', NULL, '2026-04-06 16:00:13.940833+00', NULL);
+INSERT INTO public.zip_codes VALUES ('fef414ad-a896-4299-98b7-dbfee2c61f3d', '08854', 'Piscataway', 'NJ', '2026-04-06 16:00:13.940833+00', NULL, '2026-04-06 16:00:13.940833+00', NULL);
+INSERT INTO public.zip_codes VALUES ('8e413050-f2eb-4074-8163-511d3b94b3fd', '08855', 'Piscataway', 'NJ', '2026-04-06 16:00:13.940833+00', NULL, '2026-04-06 16:00:13.940833+00', NULL);
+INSERT INTO public.zip_codes VALUES ('adba93a2-e107-48f3-88cf-5da45080ff0e', '08857', 'Old Bridge', 'NJ', '2026-04-06 16:00:13.940833+00', NULL, '2026-04-06 16:00:13.940833+00', NULL);
+INSERT INTO public.zip_codes VALUES ('d04fbdc7-e837-43f3-ab44-6264c0e940a9', '08859', 'Parlin', 'NJ', '2026-04-06 16:00:13.940833+00', NULL, '2026-04-06 16:00:13.940833+00', NULL);
+INSERT INTO public.zip_codes VALUES ('ab69d09a-6c29-4cde-addb-f4371748d6de', '08861', 'Perth Amboy', 'NJ', '2026-04-06 16:00:13.940833+00', NULL, '2026-04-06 16:00:13.940833+00', NULL);
+INSERT INTO public.zip_codes VALUES ('69c09e5c-8631-48bb-adef-353c32e5f5eb', '08862', 'Perth Amboy', 'NJ', '2026-04-06 16:00:13.940833+00', NULL, '2026-04-06 16:00:13.940833+00', NULL);
+INSERT INTO public.zip_codes VALUES ('0d05c749-63f9-48ed-baf2-33f65084b7f8', '08863', 'Fords', 'NJ', '2026-04-06 16:00:13.940833+00', NULL, '2026-04-06 16:00:13.940833+00', NULL);
+INSERT INTO public.zip_codes VALUES ('5f20465a-675b-423a-a5d4-6de067149d4f', '08871', 'Sayreville', 'NJ', '2026-04-06 16:00:13.940833+00', NULL, '2026-04-06 16:00:13.940833+00', NULL);
+INSERT INTO public.zip_codes VALUES ('be7d7d79-01b2-45a2-ac05-3d120346d4b6', '08872', 'Sayreville', 'NJ', '2026-04-06 16:00:13.940833+00', NULL, '2026-04-06 16:00:13.940833+00', NULL);
+INSERT INTO public.zip_codes VALUES ('8943792f-ae96-4696-a413-721fe71caf33', '08879', 'South Amboy', 'NJ', '2026-04-06 16:00:13.940833+00', NULL, '2026-04-06 16:00:13.940833+00', NULL);
+INSERT INTO public.zip_codes VALUES ('9897b93f-00b7-4d99-8c05-826b27593873', '08882', 'South River', 'NJ', '2026-04-06 16:00:13.940833+00', NULL, '2026-04-06 16:00:13.940833+00', NULL);
+INSERT INTO public.zip_codes VALUES ('2aa9a51a-0564-4da7-b980-0eda91e589b9', '08884', 'Spotswood', 'NJ', '2026-04-06 16:00:13.940833+00', NULL, '2026-04-06 16:00:13.940833+00', NULL);
+INSERT INTO public.zip_codes VALUES ('64953dc6-4079-4ccf-b187-32c7705c563e', '08899', 'Edison', 'NJ', '2026-04-06 16:00:13.940833+00', NULL, '2026-04-06 16:00:13.940833+00', NULL);
+INSERT INTO public.zip_codes VALUES ('e16a1a0e-ec93-4f0d-bf8d-2623a690c0de', '07001', 'Avenel', 'NJ', '2026-04-06 16:00:13.940833+00', NULL, '2026-04-06 16:00:13.940833+00', NULL);
+INSERT INTO public.zip_codes VALUES ('fe3a0d01-c823-41c4-8742-c3cf83031329', '07064', 'Port Reading', 'NJ', '2026-04-06 16:00:13.940833+00', NULL, '2026-04-06 16:00:13.940833+00', NULL);
+INSERT INTO public.zip_codes VALUES ('32285667-3190-48b9-bbb5-9f2cc3b251d9', '07067', 'Colonia', 'NJ', '2026-04-06 16:00:13.940833+00', NULL, '2026-04-06 16:00:13.940833+00', NULL);
+INSERT INTO public.zip_codes VALUES ('077a94f2-4748-41f9-97e5-5a7d89335224', '07077', 'Sewaren', 'NJ', '2026-04-06 16:00:13.940833+00', NULL, '2026-04-06 16:00:13.940833+00', NULL);
+INSERT INTO public.zip_codes VALUES ('906d89dc-a73a-4edd-aab0-8567aa1a957f', '07080', 'South Plainfield', 'NJ', '2026-04-06 16:00:13.940833+00', NULL, '2026-04-06 16:00:13.940833+00', NULL);
+INSERT INTO public.zip_codes VALUES ('c75f5e4c-2fed-41e9-b753-17c869c1b6e4', '07095', 'Woodbridge', 'NJ', '2026-04-06 16:00:13.940833+00', NULL, '2026-04-06 16:00:13.940833+00', NULL);
+INSERT INTO public.zip_codes VALUES ('0ddfd686-7ffa-462c-88eb-ff6b9199e1ee', '08810', 'Dayton', 'NJ', '2026-04-06 16:00:13.940833+00', NULL, '2026-04-06 16:00:13.940833+00', NULL);
+INSERT INTO public.zip_codes VALUES ('d80d24b3-e1f4-4479-9404-904af969161a', '08812', 'Dunellen', 'NJ', '2026-04-06 16:00:13.940833+00', NULL, '2026-04-06 16:00:13.940833+00', NULL);
+INSERT INTO public.zip_codes VALUES ('b9ca2a80-1504-4464-a9b6-c02e1ddfdd10', '08824', 'Kendall Park', 'NJ', '2026-04-06 16:00:13.940833+00', NULL, '2026-04-06 16:00:13.940833+00', NULL);
+INSERT INTO public.zip_codes VALUES ('9b197e05-6828-4918-911d-59cf52f2c68e', '08828', 'Helmetta', 'NJ', '2026-04-06 16:00:13.940833+00', NULL, '2026-04-06 16:00:13.940833+00', NULL);
+INSERT INTO public.zip_codes VALUES ('d06848b4-2783-44a1-864e-56706088bd94', '08830', 'Iselin', 'NJ', '2026-04-06 16:00:13.940833+00', NULL, '2026-04-06 16:00:13.940833+00', NULL);
+INSERT INTO public.zip_codes VALUES ('1b2bc1bf-6b29-4528-9c55-5755524ebcb0', '08831', 'Monroe Township', 'NJ', '2026-04-06 16:00:13.940833+00', NULL, '2026-04-06 16:00:13.940833+00', NULL);
+INSERT INTO public.zip_codes VALUES ('ea016f69-110d-445e-9db2-0518cfbf766e', '08832', 'Jamesburg', 'NJ', '2026-04-06 16:00:13.940833+00', NULL, '2026-04-06 16:00:13.940833+00', NULL);
+INSERT INTO public.zip_codes VALUES ('18df6c22-a8c2-4770-81b7-60de648d5af5', '08850', 'Milltown', 'NJ', '2026-04-06 16:00:13.940833+00', NULL, '2026-04-06 16:00:13.940833+00', NULL);
+INSERT INTO public.zip_codes VALUES ('1e1fa581-761f-4040-a534-ffc551750016', '08852', 'Monmouth Junction', 'NJ', '2026-04-06 16:00:13.940833+00', NULL, '2026-04-06 16:00:13.940833+00', NULL);
+INSERT INTO public.zip_codes VALUES ('f166c88f-5c52-4161-9f03-2aee6e860751', '07008', 'Carteret', 'NJ', '2026-04-06 16:00:13.940833+00', NULL, '2026-04-06 16:00:13.940833+00', NULL);
+INSERT INTO public.zip_codes VALUES ('2430b189-0dec-4d05-b0b9-60804021a5b4', '08536', 'Plainsboro', 'NJ', '2026-04-06 16:00:13.940833+00', NULL, '2026-04-06 16:00:13.940833+00', NULL);
+INSERT INTO public.zip_codes VALUES ('556813a8-65ae-4ede-bc46-8c5fe266b0c5', '08540', 'Princeton', 'NJ', '2026-04-06 16:00:13.940833+00', NULL, '2026-04-06 16:00:13.940833+00', NULL);
 
 
 --
 -- Data for Name: adult_mosquito_complaints; Type: TABLE DATA; Schema: public; Owner: -
 --
 
-INSERT INTO public.adult_mosquito_complaints VALUES ('4fd8d045-aae7-45c6-8199-065ed2a6c17e', 'John Smith', '732-555-0100', 'john@example.com', '123 Main St', NULL, '2c0ea4d2-0163-4792-9d28-d16d4c0bacf0', true, false, false, true, false, false, true, false, NULL, '2026-03-27 19:58:58.052322+00', NULL, '2026-03-27 19:58:58.052322+00', NULL);
+INSERT INTO public.adult_mosquito_complaints VALUES ('19423da0-6cd2-4f87-adcd-b49a8a78abc2', 'John Smith', '732-555-0100', 'john@example.com', '123 Main St', NULL, '2fc27ee6-7637-423a-95ec-9ad1e6da7917', true, false, false, true, false, false, true, false, NULL, '2026-04-06 16:00:13.956695+00', NULL, '2026-04-06 16:00:13.956695+00', NULL);
 
 
 --
 -- Data for Name: contact_form_submissions; Type: TABLE DATA; Schema: public; Owner: -
 --
 
-INSERT INTO public.contact_form_submissions VALUES ('d331c96e-a855-47fd-8ce5-9ebce251cd39', 'Jane Doe', 'jane@example.com', 'Question about spraying schedule', 'When will spraying occur in the 08901 area?', false, '2026-03-27 19:58:58.04476+00', NULL, '2026-03-27 19:58:58.04476+00', NULL);
+INSERT INTO public.contact_form_submissions VALUES ('91c60d1d-32d3-42de-b7ad-d1e5d98d4b68', 'Jane Doe', 'jane@example.com', 'Question about spraying schedule', 'When will spraying occur in the 08901 area?', false, '2026-04-06 16:00:13.95086+00', NULL, '2026-04-06 16:00:13.95086+00', NULL);
+
+
+--
+-- Data for Name: document_types; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+
+
+--
+-- Data for Name: documents; Type: TABLE DATA; Schema: public; Owner: -
+--
+
 
 
 --
 -- Data for Name: employees; Type: TABLE DATA; Schema: public; Owner: -
 --
 
-INSERT INTO public.employees VALUES ('4d69c0ec-4e28-4dfe-9d36-72c686d3c061', 'admin@test.local', '5e84a53d-0d00-4fe5-907c-68ef6654139b', 'Adrian Kabigting', 'Administrator', '2026-03-27 19:58:57.35373+00', NULL, '2026-03-27 19:58:57.35373+00', NULL);
-INSERT INTO public.employees VALUES ('14955551-5e25-4bbc-9af0-3154d87fda66', 'jsmith@test.local', '8909ebe2-629a-4953-b1ea-0d65161801ed', 'John Smith', 'Field Supervisor', '2026-03-27 19:58:57.480736+00', NULL, '2026-03-27 19:58:57.480736+00', NULL);
-INSERT INTO public.employees VALUES ('d8c6d3b2-78bb-4afc-81a0-6da3e78111f9', 'mgarcia@test.local', '4c2e3879-7c32-4604-b150-9f03a9ba74ac', 'Maria Garcia', 'Lab Technician', '2026-03-27 19:58:57.609527+00', NULL, '2026-03-27 19:58:57.609527+00', NULL);
-INSERT INTO public.employees VALUES ('bbdb66e9-95c1-4889-8515-c610519c6f33', 'rjohnson@test.local', 'ea7f5520-fb2e-418e-8632-8defab46a834', 'Robert Johnson', 'Operations Manager', '2026-03-27 19:58:57.729595+00', NULL, '2026-03-27 19:58:57.729595+00', NULL);
-INSERT INTO public.employees VALUES ('a041e97f-f5b6-4c69-a927-d1660386051c', 'ljones@test.local', '1ff11e3f-c362-4ebd-a4b9-df695499d705', 'Lisa Jones', 'Office Manager', '2026-03-27 19:58:57.852536+00', NULL, '2026-03-27 19:58:57.852536+00', NULL);
-INSERT INTO public.employees VALUES ('6563b223-a3af-4926-aa43-af9604e04cba', 'dwilliams@test.local', '7facae9c-e3ee-4b81-8b9b-06c8fb6c04b7', 'David Williams', 'Entomologist', '2026-03-27 19:58:57.97295+00', NULL, '2026-03-27 19:58:57.97295+00', NULL);
-INSERT INTO public.employees VALUES ('0a2c4427-920d-48f4-a1cc-952b7fb052b8', 'kbrown@test.local', NULL, 'Karen Brown', 'Field Technician', '2026-03-27 19:58:57.979762+00', NULL, '2026-03-27 19:58:57.979762+00', NULL);
-INSERT INTO public.employees VALUES ('99f5a313-08f1-45a9-a4da-cdf1a7cc1e4c', 'jdavis@test.local', NULL, 'James Davis', 'Seasonal Worker', '2026-03-27 19:58:57.979762+00', NULL, '2026-03-27 19:58:57.979762+00', NULL);
-INSERT INTO public.employees VALUES ('f32ea321-9683-4adb-9358-c5711f00a617', 'smartinez@test.local', NULL, 'Sofia Martinez', 'Lab Assistant', '2026-03-27 19:58:57.979762+00', NULL, '2026-03-27 19:58:57.979762+00', NULL);
-INSERT INTO public.employees VALUES ('f7517510-b79a-4cf5-9fa0-21025edaf20b', 'tanderson@test.local', NULL, 'Tom Anderson', NULL, '2026-03-27 19:58:57.979762+00', NULL, '2026-03-27 19:58:57.979762+00', NULL);
+INSERT INTO public.employees VALUES ('4e4fafaf-09ea-414c-ab43-21158d49c530', 'admin@test.local', 'c62f371a-d7f9-4979-acbf-5eaef2b06697', 'Adrian Kabigting', 'Administrator', '2026-04-06 16:00:13.34004+00', NULL, '2026-04-06 16:00:13.34004+00', NULL);
+INSERT INTO public.employees VALUES ('26d17513-547f-450f-80a1-921f6c226417', 'jsmith@test.local', 'fe00b13e-0f88-483a-a206-2690d8650988', 'John Smith', 'Field Supervisor', '2026-04-06 16:00:13.455016+00', NULL, '2026-04-06 16:00:13.455016+00', NULL);
+INSERT INTO public.employees VALUES ('3c7c21bd-64b0-443e-bc0b-ecf24e71a007', 'mgarcia@test.local', '2ef27411-6514-4b91-8a8e-f548be9cc723', 'Maria Garcia', 'Lab Technician', '2026-04-06 16:00:13.56351+00', NULL, '2026-04-06 16:00:13.56351+00', NULL);
+INSERT INTO public.employees VALUES ('6982f673-db2f-4448-b842-864bc546dbc7', 'rjohnson@test.local', '5fab3d2e-c474-47e6-9cb4-5db205e8a533', 'Robert Johnson', 'Operations Manager', '2026-04-06 16:00:13.670353+00', NULL, '2026-04-06 16:00:13.670353+00', NULL);
+INSERT INTO public.employees VALUES ('9b04ba4f-2bb2-4606-b8c4-3108e5d475fb', 'ljones@test.local', '1221874e-982e-4d6d-9c21-361bceec8e1b', 'Lisa Jones', 'Office Manager', '2026-04-06 16:00:13.779247+00', NULL, '2026-04-06 16:00:13.779247+00', NULL);
+INSERT INTO public.employees VALUES ('66108592-c943-4162-8a56-99b74c338926', 'dwilliams@test.local', '65c7bfeb-382f-4290-8aad-d48b5d16be52', 'David Williams', 'Entomologist', '2026-04-06 16:00:13.887088+00', NULL, '2026-04-06 16:00:13.887088+00', NULL);
+INSERT INTO public.employees VALUES ('5267fd92-be34-4bc2-b5d9-fdfbaee7050d', 'kbrown@test.local', NULL, 'Karen Brown', 'Field Technician', '2026-04-06 16:00:13.893473+00', NULL, '2026-04-06 16:00:13.893473+00', NULL);
+INSERT INTO public.employees VALUES ('c07ac109-7fe5-4750-ba22-fccd2658c541', 'jdavis@test.local', NULL, 'James Davis', 'Seasonal Worker', '2026-04-06 16:00:13.893473+00', NULL, '2026-04-06 16:00:13.893473+00', NULL);
+INSERT INTO public.employees VALUES ('47a52c05-3264-496d-b410-34472c827ea0', 'smartinez@test.local', NULL, 'Sofia Martinez', 'Lab Assistant', '2026-04-06 16:00:13.893473+00', NULL, '2026-04-06 16:00:13.893473+00', NULL);
+INSERT INTO public.employees VALUES ('2e4232d9-1b7e-4a67-bb1a-de516f20d80e', 'tanderson@test.local', NULL, 'Tom Anderson', NULL, '2026-04-06 16:00:13.893473+00', NULL, '2026-04-06 16:00:13.893473+00', NULL);
 
 
 --
 -- Data for Name: insecticides; Type: TABLE DATA; Schema: public; Owner: -
 --
 
-INSERT INTO public.insecticides VALUES ('588d4d84-f4e9-41c7-8590-34ffd71af481', 'Larvicide', 'Bacillus thuringiensis israelensis (Bti)', 'https://example.com/bti', 'VectoBac 12AS', 'https://example.com/vectobac-label', 'https://example.com/vectobac-msds', '2026-03-27 19:58:58.025096+00', NULL, '2026-03-27 19:58:58.025096+00', NULL);
-INSERT INTO public.insecticides VALUES ('396faa5c-aa7b-4ecd-aa93-1397e7b6d725', 'Adulticide', 'Sumithrin + PBO', 'https://example.com/sumithrin', 'Anvil 10+10 ULV', 'https://example.com/anvil-label', 'https://example.com/anvil-msds', '2026-03-27 19:58:58.025096+00', NULL, '2026-03-27 19:58:58.025096+00', NULL);
-INSERT INTO public.insecticides VALUES ('22aac855-d565-4c96-8c46-c8bc2a3673b1', 'Larvicide', 'Methoprene', 'https://example.com/methoprene', 'Altosid Pellets', 'https://example.com/altosid-label', 'https://example.com/altosid-msds', '2026-03-27 19:58:58.025096+00', NULL, '2026-03-27 19:58:58.025096+00', NULL);
-
-
---
--- Data for Name: meetings; Type: TABLE DATA; Schema: public; Owner: -
---
-
-INSERT INTO public.meetings VALUES ('fb0c8cc5-8f05-46ba-9142-d60ef5a38b85', 'Regular Commission Meeting', '2026-04-09 19:00:00+00', false, NULL, NULL, NULL, '2026-03-27 19:58:58.018151+00', NULL, '2026-03-27 19:58:58.018151+00', NULL, '1 JFK Blvd, New Brunswick, NJ', NULL, NULL);
-INSERT INTO public.meetings VALUES ('608a600a-867c-4c31-8aae-c497267b9a45', 'Regular Commission Meeting', '2026-05-14 19:00:00+00', false, NULL, NULL, NULL, '2026-03-27 19:58:58.018151+00', NULL, '2026-03-27 19:58:58.018151+00', NULL, '1 JFK Blvd, New Brunswick, NJ', NULL, NULL);
-INSERT INTO public.meetings VALUES ('54e57ad1-1e1c-4242-94c9-d9d1910aaa67', 'Special Budget Meeting', '2026-04-23 18:00:00+00', false, NULL, NULL, NULL, '2026-03-27 19:58:58.018151+00', NULL, '2026-03-27 19:58:58.018151+00', NULL, '1 JFK Blvd, New Brunswick, NJ', NULL, NULL);
-
-
---
--- Data for Name: mosquito_fish_requests; Type: TABLE DATA; Schema: public; Owner: -
---
-
-INSERT INTO public.mosquito_fish_requests VALUES ('960e248d-c189-4fc2-9cd9-f4d060ef870c', 'Maria Garcia', '732-555-0200', 'maria@example.com', '456 Oak Ave', NULL, 'a13c6cbd-b63d-487c-9a0c-f97b792dbebf', 'Backyard pond near fence line', 'Pond', false, NULL, '2026-03-27 19:58:58.059957+00', NULL, '2026-03-27 19:58:58.059957+00', NULL);
-
-
---
--- Data for Name: notice_types; Type: TABLE DATA; Schema: public; Owner: -
---
-
-INSERT INTO public.notice_types VALUES ('848be73c-d2e2-4f39-8478-27303aa9d82a', 'General', 'General public notices', '2026-03-27 19:58:57.996321+00', NULL, '2026-03-27 19:58:57.996321+00', NULL);
-INSERT INTO public.notice_types VALUES ('7a837580-799e-4227-9af4-8766caa5f391', 'Spraying', 'Mosquito spraying schedule notices', '2026-03-27 19:58:57.996321+00', NULL, '2026-03-27 19:58:57.996321+00', NULL);
-INSERT INTO public.notice_types VALUES ('80bb89c8-6e84-4b6b-a4ae-d15103c634f2', 'Meeting', 'Commission meeting notices', '2026-03-27 19:58:57.996321+00', NULL, '2026-03-27 19:58:57.996321+00', NULL);
-INSERT INTO public.notice_types VALUES ('2e4f4b15-7951-4d9c-a3fe-e1faf5bcdabe', 'Advisory', 'Public health advisories', '2026-03-27 19:58:57.996321+00', NULL, '2026-03-27 19:58:57.996321+00', NULL);
-
-
---
--- Data for Name: notices; Type: TABLE DATA; Schema: public; Owner: -
---
-
-INSERT INTO public.notices VALUES ('c04f956e-fbb0-4238-aaa8-32e7bd82a0e1', '7a837580-799e-4227-9af4-8766caa5f391', 'Aerial Spraying Scheduled — North District', '{"type": "doc", "content": [{"type": "paragraph", "content": [{"text": "Aerial spraying for adult mosquitoes will take place in the North District on the evening of March 28. Residents are advised to stay indoors during application.", "type": "text"}]}]}', '2026-03-27 19:58:58.011625+00', NULL, '2026-03-27 19:58:58.011625+00', NULL, '2026-03-28', true, false);
-INSERT INTO public.notices VALUES ('b88b4f4f-f02a-4737-b55a-980a4fac505e', '848be73c-d2e2-4f39-8478-27303aa9d82a', 'Seasonal Reminder: Eliminate Standing Water', '{"type": "doc", "content": [{"type": "paragraph", "content": [{"text": "As warmer weather approaches, please remove any standing water sources around your property to help reduce mosquito breeding.", "type": "text"}]}]}', '2026-03-27 19:58:58.011625+00', NULL, '2026-03-27 19:58:58.011625+00', NULL, '2026-03-15', true, false);
-INSERT INTO public.notices VALUES ('2eee98d8-05ae-44f8-bb6d-038905f242c3', '2e4f4b15-7951-4d9c-a3fe-e1faf5bcdabe', 'West Nile Virus Activity Detected', '{"type": "doc", "content": [{"type": "paragraph", "content": [{"text": "West Nile Virus has been detected in mosquito samples collected from the South District. Take precautions to avoid mosquito bites.", "type": "text"}]}]}', '2026-03-27 19:58:58.011625+00', NULL, '2026-03-27 19:58:58.011625+00', NULL, '2026-04-01', false, false);
-
-
---
--- Data for Name: permissions; Type: TABLE DATA; Schema: public; Owner: -
---
-
-INSERT INTO public.permissions VALUES ('bba4d498-51f2-4393-a39c-6490701a7ad9', 'public_notices', '2026-03-27 19:58:57.216697+00', 'Manage public notices, meetings, insecticides, and service requests');
-INSERT INTO public.permissions VALUES ('d4118ba7-8e5c-4b39-892f-9e1b001a7f82', 'manage_employees', '2026-03-27 19:58:57.216697+00', 'Manage employee records and send account invites');
-INSERT INTO public.permissions VALUES ('51e562ae-4887-4ec4-8d7a-dc6e150ebc20', 'admin_rights', '2026-03-27 19:58:57.216697+00', 'Manage user permission assignments');
-
-
---
--- Data for Name: user_permissions; Type: TABLE DATA; Schema: public; Owner: -
---
-
-INSERT INTO public.user_permissions VALUES ('b301dcba-d96a-47a3-83a5-ea0eb1057b35', '5e84a53d-0d00-4fe5-907c-68ef6654139b', '2026-03-27 19:58:57.986959+00', NULL, 'public_notices', '2026-03-27 19:58:57.986959+00', NULL);
-INSERT INTO public.user_permissions VALUES ('41d240da-3a03-4af9-a699-316726b55f4c', '5e84a53d-0d00-4fe5-907c-68ef6654139b', '2026-03-27 19:58:57.986959+00', NULL, 'manage_employees', '2026-03-27 19:58:57.986959+00', NULL);
-INSERT INTO public.user_permissions VALUES ('9da75047-9978-4943-bf6f-0116c27316bd', '5e84a53d-0d00-4fe5-907c-68ef6654139b', '2026-03-27 19:58:57.986959+00', NULL, 'admin_rights', '2026-03-27 19:58:57.986959+00', NULL);
-INSERT INTO public.user_permissions VALUES ('2a06a158-8113-4c27-98d2-2d730c39e99c', '8909ebe2-629a-4953-b1ea-0d65161801ed', '2026-03-27 19:58:57.986959+00', NULL, 'public_notices', '2026-03-27 19:58:57.986959+00', NULL);
-INSERT INTO public.user_permissions VALUES ('bab50282-ab7b-4a3f-b58d-672c0cc51921', '4c2e3879-7c32-4604-b150-9f03a9ba74ac', '2026-03-27 19:58:57.986959+00', NULL, 'public_notices', '2026-03-27 19:58:57.986959+00', NULL);
-INSERT INTO public.user_permissions VALUES ('621255be-7a9d-474c-9da2-9f08d1def113', 'ea7f5520-fb2e-418e-8632-8defab46a834', '2026-03-27 19:58:57.986959+00', NULL, 'public_notices', '2026-03-27 19:58:57.986959+00', NULL);
-INSERT INTO public.user_permissions VALUES ('805a78e7-6371-4f47-8c5f-e08dbb29481c', 'ea7f5520-fb2e-418e-8632-8defab46a834', '2026-03-27 19:58:57.986959+00', NULL, 'manage_employees', '2026-03-27 19:58:57.986959+00', NULL);
-INSERT INTO public.user_permissions VALUES ('eee22d6d-17fd-45d1-bf58-6006e9f0201a', '1ff11e3f-c362-4ebd-a4b9-df695499d705', '2026-03-27 19:58:57.986959+00', NULL, 'public_notices', '2026-03-27 19:58:57.986959+00', NULL);
-INSERT INTO public.user_permissions VALUES ('c9330cdc-a5a9-4ff8-88ec-2cfd4d065619', '1ff11e3f-c362-4ebd-a4b9-df695499d705', '2026-03-27 19:58:57.986959+00', NULL, 'manage_employees', '2026-03-27 19:58:57.986959+00', NULL);
-INSERT INTO public.user_permissions VALUES ('2ef56a53-3a97-4595-bc83-d2c53001a02e', '1ff11e3f-c362-4ebd-a4b9-df695499d705', '2026-03-27 19:58:57.986959+00', NULL, 'admin_rights', '2026-03-27 19:58:57.986959+00', NULL);
-
-
---
--- Data for Name: water_management_requests; Type: TABLE DATA; Schema: public; Owner: -
---
-
-INSERT INTO public.water_management_requests VALUES ('17bf7a1f-8106-4182-8041-f5e1badacd86', 'Bob Johnson', '732-555-0300', 'bob@example.com', '789 Elm St', NULL, 'd334fbdc-38ca-41a6-8f50-01d669c6b10d', false, false, true, 'Drainage ditch along Cedar Lane', false, NULL, '2026-03-27 19:58:58.066981+00', NULL, '2026-03-27 19:58:58.066981+00', NULL);
+INSERT INTO public.insecticides VALUES ('3ba58ce1-de0c-462a-ae7d-70a2e775ba0d', 'Larvicide', 'Bacillus thuringiensis israelensis (Bti)', 'https://example.com/bti', 'VectoBac 12AS', 'https://example.com/vectobac-label', 'https://example.com/vectobac-msds', '2026-04-06 16:00:13.934474+00', NULL, '2026-04-06 16:00:13.934474+00', NULL);
+INSERT INTO public.insecticides VALUES ('3c9ffeb8-b845-4e9f-b181-c236f062a6cf', 'Adulticide', 'Sumithrin + PBO', 'https://example.com/sumithrin', 'Anvil 10+10 ULV', 'https://example.com/anvil-label', 'https://example.com/anvil-msds', '2026-04-06 16:00:13.934474+00', NULL, '2026-04-06 16:00:13.934474+00', NULL);
+INSERT INTO public.insecticides VALUES ('628447da-d880-4013-933c-902172b4052f', 'Larvicide', 'Methoprene', 'https://example.com/methoprene', 'Altosid Pellets', 'https://example.com/altosid-label', 'https://example.com/altosid-msds', '2026-04-06 16:00:13.934474+00', NULL, '2026-04-06 16:00:13.934474+00', NULL);
 
 
 --
 -- Data for Name: job_postings; Type: TABLE DATA; Schema: public; Owner: -
 --
 
-INSERT INTO public.job_postings VALUES ('a1b2c3d4-0000-0000-0000-000000000001', 'Seasonal Field Worker', '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"The Middlesex County Mosquito Extermination Commission is seeking seasonal field workers for the upcoming mosquito control season. Duties include larviciding, adulticiding, and habitat management."}]},{"type":"heading","attrs":{"level":2},"content":[{"type":"text","text":"Requirements"}]},{"type":"bulletList","content":[{"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","text":"Valid NJ driver license"}]}]},{"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","text":"Ability to work outdoors in various weather conditions"}]}]},{"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","text":"Must be available from May through September"}]}]}]}]}', '2026-03-15 00:00:00+00', false, '2026-03-27 19:58:58.08+00', '5e84a53d-0d00-4fe5-907c-68ef6654139b', '2026-03-27 19:58:58.08+00', '5e84a53d-0d00-4fe5-907c-68ef6654139b');
-INSERT INTO public.job_postings VALUES ('a1b2c3d4-0000-0000-0000-000000000002', 'Lab Technician', '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Full-time lab technician position available. Responsible for mosquito identification, disease surveillance testing, and maintaining laboratory records."}]}]}', '2026-04-01 00:00:00+00', false, '2026-03-27 19:58:58.08+00', '5e84a53d-0d00-4fe5-907c-68ef6654139b', '2026-03-27 19:58:58.08+00', '5e84a53d-0d00-4fe5-907c-68ef6654139b');
-INSERT INTO public.job_postings VALUES ('a1b2c3d4-0000-0000-0000-000000000003', 'Equipment Mechanic (Closed)', '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"This position has been filled."}]}]}', '2026-02-01 00:00:00+00', true, '2026-03-27 19:58:58.08+00', '5e84a53d-0d00-4fe5-907c-68ef6654139b', '2026-03-27 19:58:58.08+00', '5e84a53d-0d00-4fe5-907c-68ef6654139b');
-INSERT INTO public.job_postings VALUES ('a1b2c3d4-0000-0000-0000-000000000004', 'Summer Intern (Draft)', '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Summer internship opportunity for college students studying entomology or environmental science."}]}]}', NULL, false, '2026-03-27 19:58:58.08+00', '5e84a53d-0d00-4fe5-907c-68ef6654139b', '2026-03-27 19:58:58.08+00', '5e84a53d-0d00-4fe5-907c-68ef6654139b');
+
+
+--
+-- Data for Name: meetings; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+INSERT INTO public.meetings VALUES ('6cd00d12-9356-428a-83cf-d8c9179f6ae0', 'Regular Commission Meeting', '2026-04-09 19:00:00+00', false, NULL, NULL, NULL, '2026-04-06 16:00:13.927787+00', NULL, '2026-04-06 16:00:13.927787+00', NULL, '1 JFK Blvd, New Brunswick, NJ', NULL, NULL);
+INSERT INTO public.meetings VALUES ('2692050b-9c7d-4816-aaf9-3361a68abab0', 'Regular Commission Meeting', '2026-05-14 19:00:00+00', false, NULL, NULL, NULL, '2026-04-06 16:00:13.927787+00', NULL, '2026-04-06 16:00:13.927787+00', NULL, '1 JFK Blvd, New Brunswick, NJ', NULL, NULL);
+INSERT INTO public.meetings VALUES ('33298031-5efb-4db6-bf63-d0d692cde3ca', 'Special Budget Meeting', '2026-04-23 18:00:00+00', false, NULL, NULL, NULL, '2026-04-06 16:00:13.927787+00', NULL, '2026-04-06 16:00:13.927787+00', NULL, '1 JFK Blvd, New Brunswick, NJ', NULL, NULL);
+
+
+--
+-- Data for Name: mosquito_fish_requests; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+INSERT INTO public.mosquito_fish_requests VALUES ('30a5c8f6-a1b9-4df1-98d7-efa4b20f7757', 'Maria Garcia', '732-555-0200', 'maria@example.com', '456 Oak Ave', NULL, '04e63f00-2577-47ae-8656-8dbba1694ee8', 'Backyard pond near fence line', 'Pond', false, NULL, '2026-04-06 16:00:13.963426+00', NULL, '2026-04-06 16:00:13.963426+00', NULL);
+
+
+--
+-- Data for Name: municipalities; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+INSERT INTO public.municipalities VALUES ('9fa61ea4-6596-48ea-b7a3-0e9590e22bd6', 'Carteret', '2026-04-06 16:00:13.976867+00', NULL, '2026-04-06 16:00:13.976867+00', NULL);
+INSERT INTO public.municipalities VALUES ('613959dc-ea14-4548-b5a9-a7cea0d79b82', 'Cranbury', '2026-04-06 16:00:13.976867+00', NULL, '2026-04-06 16:00:13.976867+00', NULL);
+INSERT INTO public.municipalities VALUES ('86e526a8-6e53-4dd8-bd42-10eb001d0d1b', 'Dunellen', '2026-04-06 16:00:13.976867+00', NULL, '2026-04-06 16:00:13.976867+00', NULL);
+INSERT INTO public.municipalities VALUES ('b878759a-f793-4059-b16f-6696cb7c5f78', 'East Brunswick', '2026-04-06 16:00:13.976867+00', NULL, '2026-04-06 16:00:13.976867+00', NULL);
+INSERT INTO public.municipalities VALUES ('74e59035-9e00-4a18-9144-fa8dbec908b7', 'Edison', '2026-04-06 16:00:13.976867+00', NULL, '2026-04-06 16:00:13.976867+00', NULL);
+INSERT INTO public.municipalities VALUES ('6dfafcef-9381-450c-9c51-c7d49ff0f985', 'Helmetta', '2026-04-06 16:00:13.976867+00', NULL, '2026-04-06 16:00:13.976867+00', NULL);
+INSERT INTO public.municipalities VALUES ('af92bbf3-2201-4d09-9405-c1f023f304ff', 'Highland Park', '2026-04-06 16:00:13.976867+00', NULL, '2026-04-06 16:00:13.976867+00', NULL);
+INSERT INTO public.municipalities VALUES ('e8d75d98-3db6-4dd7-b3b0-4a873394d1ca', 'Jamesburg', '2026-04-06 16:00:13.976867+00', NULL, '2026-04-06 16:00:13.976867+00', NULL);
+INSERT INTO public.municipalities VALUES ('8b70f434-2f97-49b7-89e8-109544635489', 'Metuchen', '2026-04-06 16:00:13.976867+00', NULL, '2026-04-06 16:00:13.976867+00', NULL);
+INSERT INTO public.municipalities VALUES ('7c6bb01b-16fc-4dcd-8e57-92f99ebe2203', 'Middlesex Borough', '2026-04-06 16:00:13.976867+00', NULL, '2026-04-06 16:00:13.976867+00', NULL);
+INSERT INTO public.municipalities VALUES ('fcaaffc2-4086-4240-8faf-137d1c17d824', 'Milltown', '2026-04-06 16:00:13.976867+00', NULL, '2026-04-06 16:00:13.976867+00', NULL);
+INSERT INTO public.municipalities VALUES ('c6c0ed83-32df-4598-b3c6-ccac3b5a67d5', 'Monroe', '2026-04-06 16:00:13.976867+00', NULL, '2026-04-06 16:00:13.976867+00', NULL);
+INSERT INTO public.municipalities VALUES ('5918511c-f4b1-4f88-8d5f-56f9d734d656', 'New Brunswick', '2026-04-06 16:00:13.976867+00', NULL, '2026-04-06 16:00:13.976867+00', NULL);
+INSERT INTO public.municipalities VALUES ('0c39b547-f9f9-46c7-be9f-e4dbbc0fea54', 'North Brunswick', '2026-04-06 16:00:13.976867+00', NULL, '2026-04-06 16:00:13.976867+00', NULL);
+INSERT INTO public.municipalities VALUES ('51353062-426a-4f0f-8279-9dce3291126d', 'Old Bridge', '2026-04-06 16:00:13.976867+00', NULL, '2026-04-06 16:00:13.976867+00', NULL);
+INSERT INTO public.municipalities VALUES ('51e46afa-8e03-4724-8f98-72b316204ad2', 'Perth Amboy', '2026-04-06 16:00:13.976867+00', NULL, '2026-04-06 16:00:13.976867+00', NULL);
+INSERT INTO public.municipalities VALUES ('57c8df2b-a072-465d-99e9-77eb55fe3c42', 'Piscataway', '2026-04-06 16:00:13.976867+00', NULL, '2026-04-06 16:00:13.976867+00', NULL);
+INSERT INTO public.municipalities VALUES ('90578d82-afc7-45a9-afcf-d6d22bcc7412', 'Plainsboro', '2026-04-06 16:00:13.976867+00', NULL, '2026-04-06 16:00:13.976867+00', NULL);
+INSERT INTO public.municipalities VALUES ('e63b2cd9-a685-4dfe-867e-0a9cf30365f6', 'Sayreville', '2026-04-06 16:00:13.976867+00', NULL, '2026-04-06 16:00:13.976867+00', NULL);
+INSERT INTO public.municipalities VALUES ('b39ae498-9e8e-4af5-96ff-98283e1c5b3e', 'South Amboy', '2026-04-06 16:00:13.976867+00', NULL, '2026-04-06 16:00:13.976867+00', NULL);
+INSERT INTO public.municipalities VALUES ('736f4346-fef4-4094-b3a8-7e2fa9858515', 'South Brunswick', '2026-04-06 16:00:13.976867+00', NULL, '2026-04-06 16:00:13.976867+00', NULL);
+INSERT INTO public.municipalities VALUES ('6d5586a2-73f0-4539-a382-8c4ad672cb00', 'South Plainfield', '2026-04-06 16:00:13.976867+00', NULL, '2026-04-06 16:00:13.976867+00', NULL);
+INSERT INTO public.municipalities VALUES ('58cd8763-556e-468b-a60f-d80d44fb27f6', 'South River', '2026-04-06 16:00:13.976867+00', NULL, '2026-04-06 16:00:13.976867+00', NULL);
+INSERT INTO public.municipalities VALUES ('b7d45195-cd71-4b8f-9ea2-3de006508792', 'Spotswood', '2026-04-06 16:00:13.976867+00', NULL, '2026-04-06 16:00:13.976867+00', NULL);
+INSERT INTO public.municipalities VALUES ('3472146d-3466-48a2-b71b-9b15053e06b6', 'Woodbridge', '2026-04-06 16:00:13.976867+00', NULL, '2026-04-06 16:00:13.976867+00', NULL);
+
+
+--
+-- Data for Name: notice_types; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+INSERT INTO public.notice_types VALUES ('8ef07cc3-8d80-4f21-bdd4-1265a3db8ab3', 'General', 'General public notices', '2026-04-06 16:00:13.908944+00', NULL, '2026-04-06 16:00:13.908944+00', NULL);
+INSERT INTO public.notice_types VALUES ('72b76ead-9613-4eae-8075-7a870b6e5452', 'Spraying', 'Mosquito spraying schedule notices', '2026-04-06 16:00:13.908944+00', NULL, '2026-04-06 16:00:13.908944+00', NULL);
+INSERT INTO public.notice_types VALUES ('ad276ed2-bfb4-4da8-aefc-c18d4b576d3d', 'Meeting', 'Commission meeting notices', '2026-04-06 16:00:13.908944+00', NULL, '2026-04-06 16:00:13.908944+00', NULL);
+INSERT INTO public.notice_types VALUES ('e83040c5-496d-4c35-a033-8634aaab6016', 'Advisory', 'Public health advisories', '2026-04-06 16:00:13.908944+00', NULL, '2026-04-06 16:00:13.908944+00', NULL);
+
+
+--
+-- Data for Name: notices; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+INSERT INTO public.notices VALUES ('97d29419-c66e-41d9-bb65-ed9909e8efac', '72b76ead-9613-4eae-8075-7a870b6e5452', 'Aerial Spraying Scheduled — North District', '{"type": "doc", "content": [{"type": "paragraph", "content": [{"text": "Aerial spraying for adult mosquitoes will take place in the North District on the evening of March 28. Residents are advised to stay indoors during application.", "type": "text"}]}]}', '2026-04-06 16:00:13.920536+00', NULL, '2026-04-06 16:00:13.920536+00', NULL, '2026-03-28', true, false);
+INSERT INTO public.notices VALUES ('fa3090af-99f8-4bb5-ac7e-fb844e751a79', '8ef07cc3-8d80-4f21-bdd4-1265a3db8ab3', 'Seasonal Reminder: Eliminate Standing Water', '{"type": "doc", "content": [{"type": "paragraph", "content": [{"text": "As warmer weather approaches, please remove any standing water sources around your property to help reduce mosquito breeding.", "type": "text"}]}]}', '2026-04-06 16:00:13.920536+00', NULL, '2026-04-06 16:00:13.920536+00', NULL, '2026-03-15', true, false);
+INSERT INTO public.notices VALUES ('9c28aebc-8b8e-4f41-8f46-9459f1ac5697', 'e83040c5-496d-4c35-a033-8634aaab6016', 'West Nile Virus Activity Detected', '{"type": "doc", "content": [{"type": "paragraph", "content": [{"text": "West Nile Virus has been detected in mosquito samples collected from the South District. Take precautions to avoid mosquito bites.", "type": "text"}]}]}', '2026-04-06 16:00:13.920536+00', NULL, '2026-04-06 16:00:13.920536+00', NULL, '2026-04-01', false, false);
+
+
+--
+-- Data for Name: permissions; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+INSERT INTO public.permissions VALUES ('dd32576b-294e-49fa-8666-3c888cb23c5f', 'public_notices', '2026-04-06 16:00:13.215027+00', 'Manage public notices, meetings, insecticides, and service requests');
+INSERT INTO public.permissions VALUES ('98068f43-e512-4bbc-9b9f-f031ff3780ac', 'manage_employees', '2026-04-06 16:00:13.215027+00', 'Manage employee records and send account invites');
+INSERT INTO public.permissions VALUES ('ae7070f6-58d7-443e-9dcd-607932456bd5', 'admin_rights', '2026-04-06 16:00:13.215027+00', 'Manage user permission assignments');
+
+
+--
+-- Data for Name: spray_schedules; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+INSERT INTO public.spray_schedules VALUES ('12f00954-6c1b-47d7-b3dc-612ae7913246', '2026-04-10', '19:00:00', '23:00:00', '2026-04-11', 'North District — residential areas along Route 1 corridor', NULL, 'scheduled', '3c9ffeb8-b845-4e9f-b181-c236f062a6cf', '2026-04-06 16:00:13.99+00', NULL, '2026-04-06 16:00:13.99+00', NULL);
+INSERT INTO public.spray_schedules VALUES ('feccd78b-673d-4b16-a9b1-9fdac5568f0d', '2026-04-15', '20:00:00', '23:30:00', NULL, 'South District — wetland buffer zones and parks', NULL, 'scheduled', '3c9ffeb8-b845-4e9f-b181-c236f062a6cf', '2026-04-06 16:00:14.003287+00', NULL, '2026-04-06 16:00:14.003287+00', NULL);
+INSERT INTO public.spray_schedules VALUES ('73672573-05e0-4a83-aa7d-633d819989a1', '2026-03-25', '19:30:00', '22:30:00', NULL, 'Central District — downtown and surrounding neighborhoods', 'https://maps.example.com/spray-central', 'completed', '3c9ffeb8-b845-4e9f-b181-c236f062a6cf', '2026-04-06 16:00:14.014687+00', NULL, '2026-04-06 16:00:14.014687+00', NULL);
+
+
+--
+-- Data for Name: spray_schedule_municipalities; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+INSERT INTO public.spray_schedule_municipalities VALUES ('12f00954-6c1b-47d7-b3dc-612ae7913246', '74e59035-9e00-4a18-9144-fa8dbec908b7');
+INSERT INTO public.spray_schedule_municipalities VALUES ('12f00954-6c1b-47d7-b3dc-612ae7913246', '8b70f434-2f97-49b7-89e8-109544635489');
+INSERT INTO public.spray_schedule_municipalities VALUES ('12f00954-6c1b-47d7-b3dc-612ae7913246', 'af92bbf3-2201-4d09-9405-c1f023f304ff');
+INSERT INTO public.spray_schedule_municipalities VALUES ('feccd78b-673d-4b16-a9b1-9fdac5568f0d', '51353062-426a-4f0f-8279-9dce3291126d');
+INSERT INTO public.spray_schedule_municipalities VALUES ('feccd78b-673d-4b16-a9b1-9fdac5568f0d', 'e63b2cd9-a685-4dfe-867e-0a9cf30365f6');
+INSERT INTO public.spray_schedule_municipalities VALUES ('feccd78b-673d-4b16-a9b1-9fdac5568f0d', 'b39ae498-9e8e-4af5-96ff-98283e1c5b3e');
+INSERT INTO public.spray_schedule_municipalities VALUES ('73672573-05e0-4a83-aa7d-633d819989a1', '5918511c-f4b1-4f88-8d5f-56f9d734d656');
+INSERT INTO public.spray_schedule_municipalities VALUES ('73672573-05e0-4a83-aa7d-633d819989a1', '0c39b547-f9f9-46c7-be9f-e4dbbc0fea54');
+
+
+--
+-- Data for Name: user_permissions; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+INSERT INTO public.user_permissions VALUES ('5a0e5db4-e94d-470e-bf0f-fcd256dec2ae', 'c62f371a-d7f9-4979-acbf-5eaef2b06697', '2026-04-06 16:00:13.899963+00', NULL, 'public_notices', '2026-04-06 16:00:13.899963+00', NULL);
+INSERT INTO public.user_permissions VALUES ('aa180d9e-19cb-47f4-92e0-498622aeae4d', 'c62f371a-d7f9-4979-acbf-5eaef2b06697', '2026-04-06 16:00:13.899963+00', NULL, 'manage_employees', '2026-04-06 16:00:13.899963+00', NULL);
+INSERT INTO public.user_permissions VALUES ('b3e7e800-ec68-4579-94fe-cd7a07df1699', 'c62f371a-d7f9-4979-acbf-5eaef2b06697', '2026-04-06 16:00:13.899963+00', NULL, 'admin_rights', '2026-04-06 16:00:13.899963+00', NULL);
+INSERT INTO public.user_permissions VALUES ('6fefdd94-ba1f-48d8-b0ee-c75eaffc8af8', 'fe00b13e-0f88-483a-a206-2690d8650988', '2026-04-06 16:00:13.899963+00', NULL, 'public_notices', '2026-04-06 16:00:13.899963+00', NULL);
+INSERT INTO public.user_permissions VALUES ('d18e0443-5150-4af6-99a4-721aa0f3002d', '2ef27411-6514-4b91-8a8e-f548be9cc723', '2026-04-06 16:00:13.899963+00', NULL, 'public_notices', '2026-04-06 16:00:13.899963+00', NULL);
+INSERT INTO public.user_permissions VALUES ('1f18bebf-5fe9-4807-9c79-491b43de772b', '5fab3d2e-c474-47e6-9cb4-5db205e8a533', '2026-04-06 16:00:13.899963+00', NULL, 'public_notices', '2026-04-06 16:00:13.899963+00', NULL);
+INSERT INTO public.user_permissions VALUES ('5c4c2796-3cd1-4f0a-b11d-396d49bfd523', '5fab3d2e-c474-47e6-9cb4-5db205e8a533', '2026-04-06 16:00:13.899963+00', NULL, 'manage_employees', '2026-04-06 16:00:13.899963+00', NULL);
+INSERT INTO public.user_permissions VALUES ('97b4aa99-0dab-4373-b296-c6219f6b1074', '1221874e-982e-4d6d-9c21-361bceec8e1b', '2026-04-06 16:00:13.899963+00', NULL, 'public_notices', '2026-04-06 16:00:13.899963+00', NULL);
+INSERT INTO public.user_permissions VALUES ('b3555cdb-7dc6-424a-9a6f-0d061720b643', '1221874e-982e-4d6d-9c21-361bceec8e1b', '2026-04-06 16:00:13.899963+00', NULL, 'manage_employees', '2026-04-06 16:00:13.899963+00', NULL);
+INSERT INTO public.user_permissions VALUES ('acfd4837-77ad-4190-b46b-a42fecdfa5a0', '1221874e-982e-4d6d-9c21-361bceec8e1b', '2026-04-06 16:00:13.899963+00', NULL, 'admin_rights', '2026-04-06 16:00:13.899963+00', NULL);
+
+
+--
+-- Data for Name: water_management_requests; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+INSERT INTO public.water_management_requests VALUES ('cdc0a502-c61f-4139-aaa8-ac4c57725edb', 'Bob Johnson', '732-555-0300', 'bob@example.com', '789 Elm St', NULL, 'fef414ad-a896-4299-98b7-dbfee2c61f3d', false, false, true, 'Drainage ditch along Cedar Lane', false, NULL, '2026-04-06 16:00:13.970714+00', NULL, '2026-04-06 16:00:13.970714+00', NULL);
 
 
 --


### PR DESCRIPTION
## Summary
- Add end-to-end spray schedule feature: database schema (`spray_schedules`, `municipalities`, `spray_schedule_municipalities` tables + `spray_schedule_status` enum), admin CRUD in notices app, and public display at `/spray-schedule`
- New reusable UI components: `TimeField` and `MultiComboboxField` registered in the shared form system
- Dashboard integration with stat card (scheduled/delayed/completed counts) and recent missions list
- Public page includes municipality and status filters, insecticide label/SDS links, and restricts to current-year records
- Seeds all 25 Middlesex County municipalities + sample spray schedule data

## Test plan
- [ ] Run `supabase db reset` — migration applies cleanly, municipalities and spray schedules seeded
- [ ] Run `pnpm gen-types` — `database.types.ts` includes new tables and enum
- [ ] Run `pnpm turbo run check-types` — no type errors
- [ ] Run `pnpm turbo run build` — all apps build
- [ ] Notices app: verify spray schedule CRUD (create, edit, delete) with municipality multi-select
- [ ] Notices app: verify dashboard shows spray mission stat card and recent missions
- [ ] Public app: verify `/spray-schedule` displays missions with filters, insecticide links, rain date
- [ ] Public app: verify only current-year records are shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)