### PR TITLE
feat: refresh public website design

### DIFF
--- a/.changeset/public-design-refresh.md
+++ b/.changeset/public-design-refresh.md
@@ -1,0 +1,6 @@
+---
+"public": minor
+"@mcmec/ui": minor
+---
+
+Refresh public website design: add Roboto font, refine color palette and shadows, reduce desktop typography scale, add section sidebar navigation, restructure home page with action cards, expand footer with site-wide links, and improve mobile navigation.

--- a/apps/public/src/components/footer.tsx
+++ b/apps/public/src/components/footer.tsx
@@ -12,37 +12,105 @@ export function Footer() {
 		COMPANY_INFO.fax,
 	).formatNational();
 	return (
-		<footer className="w-full border-t bg-accent p-4 text-bg-foreground">
-			<div className="flex flex-row flex-wrap items-center justify-start gap-8 px-4">
-				<a
-					href="https://www.middlesexcountynj.gov/government/departments/department-of-public-safety-and-health/middlesex-county-mosquito-commission"
-					rel="noreferrer"
-					target="_blank"
-				>
-					<img alt="Logo" className="h-12" src={countyLogo} />
-				</a>
-				<div className="flex flex-col gap-0 leading-tight">
-					<span className="font-extrabold uppercase tracking-wide">
-						{COMPANY_INFO.nameLine1}
-					</span>
-					<span className="font-bold uppercase tracking-wide">
-						{COMPANY_INFO.nameLine2}
-					</span>
-					<span>{COMPANY_INFO.addressLine1}</span>
-					<span>{COMPANY_INFO.addressLine2}</span>
-					<span className="flex flex-row items-center gap-2">
-						<Phone size={18} /> {phoneNumber}
-					</span>
-					<span className="flex flex-row items-center gap-2">
-						<Printer size={18} /> {faxNumber}
-					</span>
-				</div>
-				<div className="flex h-full flex-col gap-0 leading-tight">
-					<div className="mb-4 font-bold uppercase tracking-wide">
-						Contact Us
+		<footer className="w-full border-t bg-accent text-accent-foreground/70">
+			<div className="mx-auto max-w-7xl px-6 py-10 md:px-12">
+				<div className="grid grid-cols-1 gap-8 text-center sm:grid-cols-2 sm:text-left lg:grid-cols-4">
+					{/* Agency Info */}
+					<div className="flex flex-col items-center gap-3 sm:items-start">
+						<a
+							href="https://www.middlesexcountynj.gov/government/departments/department-of-public-safety-and-health/middlesex-county-mosquito-commission"
+							rel="noreferrer"
+							target="_blank"
+						>
+							<img
+								alt="Middlesex County Logo"
+								className="h-12"
+								src={countyLogo}
+							/>
+						</a>
+						<div className="flex flex-col items-center text-sm leading-relaxed sm:items-start">
+							<span className="font-bold uppercase tracking-wide">
+								{COMPANY_INFO.nameLine1}
+							</span>
+							<span className="font-semibold uppercase tracking-wide">
+								{COMPANY_INFO.nameLine2}
+							</span>
+							<span>{COMPANY_INFO.addressLine1}</span>
+							<span>{COMPANY_INFO.addressLine2}</span>
+							<span className="mt-1 flex items-center justify-center gap-2 sm:justify-start">
+								<Phone size={14} /> {phoneNumber}
+							</span>
+							<span className="flex items-center justify-center gap-2 sm:justify-start">
+								<Printer size={14} /> {faxNumber}
+							</span>
+						</div>
 					</div>
-					<a href="mailto:clerk@middlesexmosquito.org">E-mail Us</a>
-					<Link to="/notices">Public Notices</Link>
+
+					{/* Quick Links */}
+					<div className="flex flex-col gap-2">
+						<h3 className="font-bold text-sm uppercase tracking-wide">
+							Quick Links
+						</h3>
+						<nav className="flex flex-col gap-1 text-sm">
+							<Link className="hover:underline" to="/contact/service-request">
+								Request Service
+							</Link>
+							<Link
+								className="hover:underline"
+								to="/mosquito-control/spray-schedule"
+							>
+								Spray Schedule
+							</Link>
+							<Link
+								className="hover:underline"
+								to="/mosquito-surveillance/weekly-activity"
+							>
+								Weekly Mosquito Activity
+							</Link>
+							<Link className="hover:underline" to="/job-opportunities">
+								Job Opportunities
+							</Link>
+						</nav>
+					</div>
+
+					{/* Public Information */}
+					<div className="flex flex-col gap-2">
+						<h3 className="font-bold text-sm uppercase tracking-wide">
+							Public Information
+						</h3>
+						<nav className="flex flex-col gap-1 text-sm">
+							<Link className="hover:underline" to="/notices">
+								Legal Notices
+							</Link>
+							<Link className="hover:underline" to="/notices/meetings">
+								Public Meetings
+							</Link>
+							<Link className="hover:underline" to="/notices/transparency">
+								Transparency
+							</Link>
+							<Link className="hover:underline" to="/notices/archive">
+								Archived Notices
+							</Link>
+						</nav>
+					</div>
+
+					{/* Contact */}
+					<div className="flex flex-col gap-2">
+						<h3 className="font-bold text-sm uppercase tracking-wide">
+							Contact Us
+						</h3>
+						<nav className="flex flex-col gap-1 text-sm">
+							<a
+								className="hover:underline"
+								href="mailto:clerk@middlesexmosquito.org"
+							>
+								E-mail Us
+							</a>
+							<Link className="hover:underline" to="/contact/contact-us">
+								Contact Form
+							</Link>
+						</nav>
+					</div>
 				</div>
 			</div>
 		</footer>

--- a/apps/public/src/components/nav-bar.tsx
+++ b/apps/public/src/components/nav-bar.tsx
@@ -18,7 +18,6 @@ import {
 	SheetTitle,
 	SheetTrigger,
 } from "@mcmec/ui/components/sheet";
-import { useIsMobile } from "@mcmec/ui/hooks/use-mobile";
 import { Link, type LinkProps } from "@tanstack/react-router";
 import { ChevronDown, Menu } from "lucide-react";
 import { useState } from "react";
@@ -152,23 +151,29 @@ const menuItems: MenuItem[] = [
 ];
 
 export function Navbar() {
-	const isMobile = useIsMobile();
-	if (isMobile) {
-		return <MobileNavBar />;
-	} else {
-		return <WebNavBar />;
-	}
+	return (
+		<>
+			{/* Mobile: menu button + sheet */}
+			<div className="md:hidden">
+				<MobileNavBar />
+			</div>
+			{/* Desktop: full nav bar */}
+			<div className="hidden md:block">
+				<WebNavBar />
+			</div>
+		</>
+	);
 }
 
 const navLinkClass =
-	"inline-flex h-12 items-center justify-center rounded-md px-4 py-2 text-2xl text-primary-foreground font-bold uppercase tracking-wider hover:bg-accent/40 focus:bg-accent/40 focus-visible:ring-ring/50 outline-none transition-[color,box-shadow] focus-visible:ring-[3px]";
+	"inline-flex h-10 items-center justify-center rounded-md px-3 py-1.5 font-semibold text-primary-foreground text-sm uppercase tracking-wide outline-none transition-[color,box-shadow] hover:bg-accent/40 focus:bg-accent/40 focus-visible:ring-[3px] focus-visible:ring-ring/50";
 
 function WebNavBar() {
 	return (
-		<div className="sticky top-0 z-50 flex h-30 flex-row items-center justify-start bg-primary py-2 drop-shadow-accent drop-shadow-xl">
-			<div className="flex w-50 flex-row justify-center rounded-r-full bg-background">
+		<div className="sticky top-0 z-50 flex h-16 flex-row items-center justify-start bg-primary py-2 shadow-md">
+			<div className="flex w-20 flex-row justify-center rounded-r-full bg-background">
 				<Link to="/">
-					<img alt="MCMEC Logo" className="m-4 h-26" src={logo512} />
+					<img alt="MCMEC Logo" className="m-2 h-12" src={logo512} />
 				</Link>
 			</div>
 
@@ -203,7 +208,7 @@ function NavPopover({ item }: { item: MenuItem }) {
 					className={`ml-1 size-4 transition duration-200 ${open ? "rotate-180" : ""}`}
 				/>
 			</PopoverTrigger>
-			<PopoverContent align="start" className="w-100" sideOffset={8}>
+			<PopoverContent align="start" className="w-80" sideOffset={8}>
 				<ul className="grid gap-2">
 					{item.subItems?.map((subItem) => (
 						<li key={subItem.title}>
@@ -212,9 +217,9 @@ function NavPopover({ item }: { item: MenuItem }) {
 								onClick={() => setOpen(false)}
 								to={subItem.linkProps.to}
 							>
-								<div className="font-semibold text-xl">{subItem.title}</div>
+								<div className="font-semibold text-sm">{subItem.title}</div>
 								{subItem.description && (
-									<div className="text-muted-foreground">
+									<div className="text-muted-foreground text-xs">
 										{subItem.description}
 									</div>
 								)}
@@ -231,12 +236,14 @@ function MobileNavBar() {
 	const [open, setOpen] = useState(false);
 
 	return (
-		<div className="flex h-15 flex-row items-center justify-between bg-primary py-2 pl-2">
+		<div className="sticky top-0 z-50 flex h-14 flex-row items-center justify-between bg-primary pl-3">
 			<Sheet aria-describedby="Mobile Menu" onOpenChange={setOpen} open={open}>
 				<SheetTrigger>
 					<div className="flex flex-row items-center gap-2 text-primary-foreground">
-						<Menu />
-						<span className="text-2xl uppercase tracking-tight">Menu</span>
+						<Menu className="size-5" />
+						<span className="font-semibold text-sm uppercase tracking-wide">
+							Menu
+						</span>
 					</div>
 				</SheetTrigger>
 				<SheetContent side="left">
@@ -258,20 +265,15 @@ function MobileNavBar() {
 											</Button>
 										</CollapsibleTrigger>
 										<CollapsibleContent className="pt-2 pl-4">
-											<div className="flex flex-col gap-2">
+											<div className="flex flex-col gap-1">
 												{item.subItems.map((subItem) => (
 													<Link
-														className="block rounded-md p-2 hover:bg-accent"
+														className="block rounded-md p-2 text-sm hover:bg-muted"
 														key={subItem.title}
 														onClick={() => setOpen(false)}
 														to={subItem.linkProps.to}
 													>
-														<div className="font-semibold">{subItem.title}</div>
-														{subItem.description && (
-															<div className="text-muted-foreground text-xs">
-																{subItem.description}
-															</div>
-														)}
+														{subItem.title}
 													</Link>
 												))}
 											</div>
@@ -291,17 +293,18 @@ function MobileNavBar() {
 										</Link>
 									</Button>
 								)}
-								{index < menuItems.length - 1 && <Separator className="my-2" />}
+								{index < menuItems.length - 1 && <Separator className="my-1" />}
 							</div>
 						))}
 					</div>
 				</SheetContent>
 			</Sheet>
-			<div className="flex w-24 flex-row justify-center rounded-l-full bg-background">
-				<Link to="/">
-					<img alt="MCMEC Logo" className="m-4 h-15" src={logo512} />
-				</Link>
-			</div>
+			<Link
+				className="flex h-14 w-16 items-center justify-center rounded-l-full bg-background"
+				to="/"
+			>
+				<img alt="MCMEC Logo" className="h-10" src={logo512} />
+			</Link>
 		</div>
 	);
 }

--- a/apps/public/src/routeTree.gen.ts
+++ b/apps/public/src/routeTree.gen.ts
@@ -10,6 +10,11 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as SprayScheduleRouteImport } from './routes/spray-schedule'
+import { Route as NoticesRouteImport } from './routes/notices'
+import { Route as MosquitoSurveillanceRouteImport } from './routes/mosquito-surveillance'
+import { Route as MosquitoControlRouteImport } from './routes/mosquito-control'
+import { Route as ContactRouteImport } from './routes/contact'
+import { Route as AboutRouteImport } from './routes/about'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as NoticesIndexRouteImport } from './routes/notices/index'
 import { Route as JobOpportunitiesIndexRouteImport } from './routes/job-opportunities/index'
@@ -45,15 +50,40 @@ const SprayScheduleRoute = SprayScheduleRouteImport.update({
   path: '/spray-schedule',
   getParentRoute: () => rootRouteImport,
 } as any)
+const NoticesRoute = NoticesRouteImport.update({
+  id: '/notices',
+  path: '/notices',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const MosquitoSurveillanceRoute = MosquitoSurveillanceRouteImport.update({
+  id: '/mosquito-surveillance',
+  path: '/mosquito-surveillance',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const MosquitoControlRoute = MosquitoControlRouteImport.update({
+  id: '/mosquito-control',
+  path: '/mosquito-control',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ContactRoute = ContactRouteImport.update({
+  id: '/contact',
+  path: '/contact',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const AboutRoute = AboutRouteImport.update({
+  id: '/about',
+  path: '/about',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
 const NoticesIndexRoute = NoticesIndexRouteImport.update({
-  id: '/notices/',
-  path: '/notices/',
-  getParentRoute: () => rootRouteImport,
+  id: '/',
+  path: '/',
+  getParentRoute: () => NoticesRoute,
 } as any)
 const JobOpportunitiesIndexRoute = JobOpportunitiesIndexRouteImport.update({
   id: '/job-opportunities/',
@@ -61,72 +91,72 @@ const JobOpportunitiesIndexRoute = JobOpportunitiesIndexRouteImport.update({
   getParentRoute: () => rootRouteImport,
 } as any)
 const NoticesTransparencyRoute = NoticesTransparencyRouteImport.update({
-  id: '/notices/transparency',
-  path: '/notices/transparency',
-  getParentRoute: () => rootRouteImport,
+  id: '/transparency',
+  path: '/transparency',
+  getParentRoute: () => NoticesRoute,
 } as any)
 const NoticesMeetingsRoute = NoticesMeetingsRouteImport.update({
-  id: '/notices/meetings',
-  path: '/notices/meetings',
-  getParentRoute: () => rootRouteImport,
+  id: '/meetings',
+  path: '/meetings',
+  getParentRoute: () => NoticesRoute,
 } as any)
 const NoticesArchiveRoute = NoticesArchiveRouteImport.update({
-  id: '/notices/archive',
-  path: '/notices/archive',
-  getParentRoute: () => rootRouteImport,
+  id: '/archive',
+  path: '/archive',
+  getParentRoute: () => NoticesRoute,
 } as any)
 const NoticesNoticeIdRoute = NoticesNoticeIdRouteImport.update({
-  id: '/notices/$noticeId',
-  path: '/notices/$noticeId',
-  getParentRoute: () => rootRouteImport,
+  id: '/$noticeId',
+  path: '/$noticeId',
+  getParentRoute: () => NoticesRoute,
 } as any)
 const MosquitoSurveillanceWeeklyActivityRoute =
   MosquitoSurveillanceWeeklyActivityRouteImport.update({
-    id: '/mosquito-surveillance/weekly-activity',
-    path: '/mosquito-surveillance/weekly-activity',
-    getParentRoute: () => rootRouteImport,
+    id: '/weekly-activity',
+    path: '/weekly-activity',
+    getParentRoute: () => MosquitoSurveillanceRoute,
   } as any)
 const MosquitoSurveillanceMunicipalPacketRoute =
   MosquitoSurveillanceMunicipalPacketRouteImport.update({
-    id: '/mosquito-surveillance/municipal-packet',
-    path: '/mosquito-surveillance/municipal-packet',
-    getParentRoute: () => rootRouteImport,
+    id: '/municipal-packet',
+    path: '/municipal-packet',
+    getParentRoute: () => MosquitoSurveillanceRoute,
   } as any)
 const MosquitoSurveillanceMosquitoSourceChecklistRoute =
   MosquitoSurveillanceMosquitoSourceChecklistRouteImport.update({
-    id: '/mosquito-surveillance/mosquito-source-checklist',
-    path: '/mosquito-surveillance/mosquito-source-checklist',
-    getParentRoute: () => rootRouteImport,
+    id: '/mosquito-source-checklist',
+    path: '/mosquito-source-checklist',
+    getParentRoute: () => MosquitoSurveillanceRoute,
   } as any)
 const MosquitoControlSprayScheduleRoute =
   MosquitoControlSprayScheduleRouteImport.update({
-    id: '/mosquito-control/spray-schedule',
-    path: '/mosquito-control/spray-schedule',
-    getParentRoute: () => rootRouteImport,
+    id: '/spray-schedule',
+    path: '/spray-schedule',
+    getParentRoute: () => MosquitoControlRoute,
   } as any)
 const MosquitoControlSprayNoticeRoute =
   MosquitoControlSprayNoticeRouteImport.update({
-    id: '/mosquito-control/spray-notice',
-    path: '/mosquito-control/spray-notice',
-    getParentRoute: () => rootRouteImport,
+    id: '/spray-notice',
+    path: '/spray-notice',
+    getParentRoute: () => MosquitoControlRoute,
   } as any)
 const MosquitoControlMosquitoControlProductsRoute =
   MosquitoControlMosquitoControlProductsRouteImport.update({
-    id: '/mosquito-control/mosquito-control-products',
-    path: '/mosquito-control/mosquito-control-products',
-    getParentRoute: () => rootRouteImport,
+    id: '/mosquito-control-products',
+    path: '/mosquito-control-products',
+    getParentRoute: () => MosquitoControlRoute,
   } as any)
 const MosquitoControlHowWeControlMosquitoesRoute =
   MosquitoControlHowWeControlMosquitoesRouteImport.update({
-    id: '/mosquito-control/how-we-control-mosquitoes',
-    path: '/mosquito-control/how-we-control-mosquitoes',
-    getParentRoute: () => rootRouteImport,
+    id: '/how-we-control-mosquitoes',
+    path: '/how-we-control-mosquitoes',
+    getParentRoute: () => MosquitoControlRoute,
   } as any)
 const MosquitoControlAerialLarvicidingNoticeRoute =
   MosquitoControlAerialLarvicidingNoticeRouteImport.update({
-    id: '/mosquito-control/aerial-larviciding-notice',
-    path: '/mosquito-control/aerial-larviciding-notice',
-    getParentRoute: () => rootRouteImport,
+    id: '/aerial-larviciding-notice',
+    path: '/aerial-larviciding-notice',
+    getParentRoute: () => MosquitoControlRoute,
   } as any)
 const JobOpportunitiesPostingIdRoute =
   JobOpportunitiesPostingIdRouteImport.update({
@@ -136,79 +166,84 @@ const JobOpportunitiesPostingIdRoute =
   } as any)
 const ContactWaterManagementRequestsRoute =
   ContactWaterManagementRequestsRouteImport.update({
-    id: '/contact/water-management-requests',
-    path: '/contact/water-management-requests',
-    getParentRoute: () => rootRouteImport,
+    id: '/water-management-requests',
+    path: '/water-management-requests',
+    getParentRoute: () => ContactRoute,
   } as any)
 const ContactServiceRequestRoute = ContactServiceRequestRouteImport.update({
-  id: '/contact/service-request',
-  path: '/contact/service-request',
-  getParentRoute: () => rootRouteImport,
+  id: '/service-request',
+  path: '/service-request',
+  getParentRoute: () => ContactRoute,
 } as any)
 const ContactRequestSuccessRoute = ContactRequestSuccessRouteImport.update({
-  id: '/contact/request-success',
-  path: '/contact/request-success',
-  getParentRoute: () => rootRouteImport,
+  id: '/request-success',
+  path: '/request-success',
+  getParentRoute: () => ContactRoute,
 } as any)
 const ContactMosquitofishRequestsRoute =
   ContactMosquitofishRequestsRouteImport.update({
-    id: '/contact/mosquitofish-requests',
-    path: '/contact/mosquitofish-requests',
-    getParentRoute: () => rootRouteImport,
+    id: '/mosquitofish-requests',
+    path: '/mosquitofish-requests',
+    getParentRoute: () => ContactRoute,
   } as any)
 const ContactContactUsRoute = ContactContactUsRouteImport.update({
-  id: '/contact/contact-us',
-  path: '/contact/contact-us',
-  getParentRoute: () => rootRouteImport,
+  id: '/contact-us',
+  path: '/contact-us',
+  getParentRoute: () => ContactRoute,
 } as any)
 const ContactAdultMosquitoRequestsRoute =
   ContactAdultMosquitoRequestsRouteImport.update({
-    id: '/contact/adult-mosquito-requests',
-    path: '/contact/adult-mosquito-requests',
-    getParentRoute: () => rootRouteImport,
+    id: '/adult-mosquito-requests',
+    path: '/adult-mosquito-requests',
+    getParentRoute: () => ContactRoute,
   } as any)
 const AboutMosquitoControlProductsRoute =
   AboutMosquitoControlProductsRouteImport.update({
-    id: '/about/mosquito-control-products',
-    path: '/about/mosquito-control-products',
-    getParentRoute: () => rootRouteImport,
+    id: '/mosquito-control-products',
+    path: '/mosquito-control-products',
+    getParentRoute: () => AboutRoute,
   } as any)
 const AboutMissionStatementRoute = AboutMissionStatementRouteImport.update({
-  id: '/about/mission-statement',
-  path: '/about/mission-statement',
-  getParentRoute: () => rootRouteImport,
+  id: '/mission-statement',
+  path: '/mission-statement',
+  getParentRoute: () => AboutRoute,
 } as any)
 const AboutMissionRoute = AboutMissionRouteImport.update({
-  id: '/about/mission',
-  path: '/about/mission',
-  getParentRoute: () => rootRouteImport,
+  id: '/mission',
+  path: '/mission',
+  getParentRoute: () => AboutRoute,
 } as any)
 const AboutLeadershipRoute = AboutLeadershipRouteImport.update({
-  id: '/about/leadership',
-  path: '/about/leadership',
-  getParentRoute: () => rootRouteImport,
+  id: '/leadership',
+  path: '/leadership',
+  getParentRoute: () => AboutRoute,
 } as any)
 const AboutHowWeControlMosquitoesRoute =
   AboutHowWeControlMosquitoesRouteImport.update({
-    id: '/about/how-we-control-mosquitoes',
-    path: '/about/how-we-control-mosquitoes',
-    getParentRoute: () => rootRouteImport,
+    id: '/how-we-control-mosquitoes',
+    path: '/how-we-control-mosquitoes',
+    getParentRoute: () => AboutRoute,
   } as any)
 const AboutJobOpportunitiesIndexRoute =
   AboutJobOpportunitiesIndexRouteImport.update({
-    id: '/about/job-opportunities/',
-    path: '/about/job-opportunities/',
-    getParentRoute: () => rootRouteImport,
+    id: '/job-opportunities/',
+    path: '/job-opportunities/',
+    getParentRoute: () => AboutRoute,
   } as any)
 const AboutJobOpportunitiesPostingIdRoute =
   AboutJobOpportunitiesPostingIdRouteImport.update({
-    id: '/about/job-opportunities/$postingId',
-    path: '/about/job-opportunities/$postingId',
-    getParentRoute: () => rootRouteImport,
+    id: '/job-opportunities/$postingId',
+    path: '/job-opportunities/$postingId',
+    getParentRoute: () => AboutRoute,
   } as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/about': typeof AboutRouteWithChildren
+  '/contact': typeof ContactRouteWithChildren
+  '/mosquito-control': typeof MosquitoControlRouteWithChildren
+  '/mosquito-surveillance': typeof MosquitoSurveillanceRouteWithChildren
+  '/notices': typeof NoticesRouteWithChildren
   '/spray-schedule': typeof SprayScheduleRoute
   '/about/how-we-control-mosquitoes': typeof AboutHowWeControlMosquitoesRoute
   '/about/leadership': typeof AboutLeadershipRoute
@@ -241,6 +276,10 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/about': typeof AboutRouteWithChildren
+  '/contact': typeof ContactRouteWithChildren
+  '/mosquito-control': typeof MosquitoControlRouteWithChildren
+  '/mosquito-surveillance': typeof MosquitoSurveillanceRouteWithChildren
   '/spray-schedule': typeof SprayScheduleRoute
   '/about/how-we-control-mosquitoes': typeof AboutHowWeControlMosquitoesRoute
   '/about/leadership': typeof AboutLeadershipRoute
@@ -274,6 +313,11 @@ export interface FileRoutesByTo {
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/about': typeof AboutRouteWithChildren
+  '/contact': typeof ContactRouteWithChildren
+  '/mosquito-control': typeof MosquitoControlRouteWithChildren
+  '/mosquito-surveillance': typeof MosquitoSurveillanceRouteWithChildren
+  '/notices': typeof NoticesRouteWithChildren
   '/spray-schedule': typeof SprayScheduleRoute
   '/about/how-we-control-mosquitoes': typeof AboutHowWeControlMosquitoesRoute
   '/about/leadership': typeof AboutLeadershipRoute
@@ -308,6 +352,11 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/about'
+    | '/contact'
+    | '/mosquito-control'
+    | '/mosquito-surveillance'
+    | '/notices'
     | '/spray-schedule'
     | '/about/how-we-control-mosquitoes'
     | '/about/leadership'
@@ -340,6 +389,10 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/about'
+    | '/contact'
+    | '/mosquito-control'
+    | '/mosquito-surveillance'
     | '/spray-schedule'
     | '/about/how-we-control-mosquitoes'
     | '/about/leadership'
@@ -372,6 +425,11 @@ export interface FileRouteTypes {
   id:
     | '__root__'
     | '/'
+    | '/about'
+    | '/contact'
+    | '/mosquito-control'
+    | '/mosquito-surveillance'
+    | '/notices'
     | '/spray-schedule'
     | '/about/how-we-control-mosquitoes'
     | '/about/leadership'
@@ -405,35 +463,14 @@ export interface FileRouteTypes {
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  AboutRoute: typeof AboutRouteWithChildren
+  ContactRoute: typeof ContactRouteWithChildren
+  MosquitoControlRoute: typeof MosquitoControlRouteWithChildren
+  MosquitoSurveillanceRoute: typeof MosquitoSurveillanceRouteWithChildren
+  NoticesRoute: typeof NoticesRouteWithChildren
   SprayScheduleRoute: typeof SprayScheduleRoute
-  AboutHowWeControlMosquitoesRoute: typeof AboutHowWeControlMosquitoesRoute
-  AboutLeadershipRoute: typeof AboutLeadershipRoute
-  AboutMissionRoute: typeof AboutMissionRoute
-  AboutMissionStatementRoute: typeof AboutMissionStatementRoute
-  AboutMosquitoControlProductsRoute: typeof AboutMosquitoControlProductsRoute
-  ContactAdultMosquitoRequestsRoute: typeof ContactAdultMosquitoRequestsRoute
-  ContactContactUsRoute: typeof ContactContactUsRoute
-  ContactMosquitofishRequestsRoute: typeof ContactMosquitofishRequestsRoute
-  ContactRequestSuccessRoute: typeof ContactRequestSuccessRoute
-  ContactServiceRequestRoute: typeof ContactServiceRequestRoute
-  ContactWaterManagementRequestsRoute: typeof ContactWaterManagementRequestsRoute
   JobOpportunitiesPostingIdRoute: typeof JobOpportunitiesPostingIdRoute
-  MosquitoControlAerialLarvicidingNoticeRoute: typeof MosquitoControlAerialLarvicidingNoticeRoute
-  MosquitoControlHowWeControlMosquitoesRoute: typeof MosquitoControlHowWeControlMosquitoesRoute
-  MosquitoControlMosquitoControlProductsRoute: typeof MosquitoControlMosquitoControlProductsRoute
-  MosquitoControlSprayNoticeRoute: typeof MosquitoControlSprayNoticeRoute
-  MosquitoControlSprayScheduleRoute: typeof MosquitoControlSprayScheduleRoute
-  MosquitoSurveillanceMosquitoSourceChecklistRoute: typeof MosquitoSurveillanceMosquitoSourceChecklistRoute
-  MosquitoSurveillanceMunicipalPacketRoute: typeof MosquitoSurveillanceMunicipalPacketRoute
-  MosquitoSurveillanceWeeklyActivityRoute: typeof MosquitoSurveillanceWeeklyActivityRoute
-  NoticesNoticeIdRoute: typeof NoticesNoticeIdRoute
-  NoticesArchiveRoute: typeof NoticesArchiveRoute
-  NoticesMeetingsRoute: typeof NoticesMeetingsRoute
-  NoticesTransparencyRoute: typeof NoticesTransparencyRoute
   JobOpportunitiesIndexRoute: typeof JobOpportunitiesIndexRoute
-  NoticesIndexRoute: typeof NoticesIndexRoute
-  AboutJobOpportunitiesPostingIdRoute: typeof AboutJobOpportunitiesPostingIdRoute
-  AboutJobOpportunitiesIndexRoute: typeof AboutJobOpportunitiesIndexRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -445,6 +482,41 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof SprayScheduleRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/notices': {
+      id: '/notices'
+      path: '/notices'
+      fullPath: '/notices'
+      preLoaderRoute: typeof NoticesRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/mosquito-surveillance': {
+      id: '/mosquito-surveillance'
+      path: '/mosquito-surveillance'
+      fullPath: '/mosquito-surveillance'
+      preLoaderRoute: typeof MosquitoSurveillanceRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/mosquito-control': {
+      id: '/mosquito-control'
+      path: '/mosquito-control'
+      fullPath: '/mosquito-control'
+      preLoaderRoute: typeof MosquitoControlRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/contact': {
+      id: '/contact'
+      path: '/contact'
+      fullPath: '/contact'
+      preLoaderRoute: typeof ContactRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/about': {
+      id: '/about'
+      path: '/about'
+      fullPath: '/about'
+      preLoaderRoute: typeof AboutRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/': {
       id: '/'
       path: '/'
@@ -454,10 +526,10 @@ declare module '@tanstack/react-router' {
     }
     '/notices/': {
       id: '/notices/'
-      path: '/notices'
+      path: '/'
       fullPath: '/notices/'
       preLoaderRoute: typeof NoticesIndexRouteImport
-      parentRoute: typeof rootRouteImport
+      parentRoute: typeof NoticesRoute
     }
     '/job-opportunities/': {
       id: '/job-opportunities/'
@@ -468,87 +540,87 @@ declare module '@tanstack/react-router' {
     }
     '/notices/transparency': {
       id: '/notices/transparency'
-      path: '/notices/transparency'
+      path: '/transparency'
       fullPath: '/notices/transparency'
       preLoaderRoute: typeof NoticesTransparencyRouteImport
-      parentRoute: typeof rootRouteImport
+      parentRoute: typeof NoticesRoute
     }
     '/notices/meetings': {
       id: '/notices/meetings'
-      path: '/notices/meetings'
+      path: '/meetings'
       fullPath: '/notices/meetings'
       preLoaderRoute: typeof NoticesMeetingsRouteImport
-      parentRoute: typeof rootRouteImport
+      parentRoute: typeof NoticesRoute
     }
     '/notices/archive': {
       id: '/notices/archive'
-      path: '/notices/archive'
+      path: '/archive'
       fullPath: '/notices/archive'
       preLoaderRoute: typeof NoticesArchiveRouteImport
-      parentRoute: typeof rootRouteImport
+      parentRoute: typeof NoticesRoute
     }
     '/notices/$noticeId': {
       id: '/notices/$noticeId'
-      path: '/notices/$noticeId'
+      path: '/$noticeId'
       fullPath: '/notices/$noticeId'
       preLoaderRoute: typeof NoticesNoticeIdRouteImport
-      parentRoute: typeof rootRouteImport
+      parentRoute: typeof NoticesRoute
     }
     '/mosquito-surveillance/weekly-activity': {
       id: '/mosquito-surveillance/weekly-activity'
-      path: '/mosquito-surveillance/weekly-activity'
+      path: '/weekly-activity'
       fullPath: '/mosquito-surveillance/weekly-activity'
       preLoaderRoute: typeof MosquitoSurveillanceWeeklyActivityRouteImport
-      parentRoute: typeof rootRouteImport
+      parentRoute: typeof MosquitoSurveillanceRoute
     }
     '/mosquito-surveillance/municipal-packet': {
       id: '/mosquito-surveillance/municipal-packet'
-      path: '/mosquito-surveillance/municipal-packet'
+      path: '/municipal-packet'
       fullPath: '/mosquito-surveillance/municipal-packet'
       preLoaderRoute: typeof MosquitoSurveillanceMunicipalPacketRouteImport
-      parentRoute: typeof rootRouteImport
+      parentRoute: typeof MosquitoSurveillanceRoute
     }
     '/mosquito-surveillance/mosquito-source-checklist': {
       id: '/mosquito-surveillance/mosquito-source-checklist'
-      path: '/mosquito-surveillance/mosquito-source-checklist'
+      path: '/mosquito-source-checklist'
       fullPath: '/mosquito-surveillance/mosquito-source-checklist'
       preLoaderRoute: typeof MosquitoSurveillanceMosquitoSourceChecklistRouteImport
-      parentRoute: typeof rootRouteImport
+      parentRoute: typeof MosquitoSurveillanceRoute
     }
     '/mosquito-control/spray-schedule': {
       id: '/mosquito-control/spray-schedule'
-      path: '/mosquito-control/spray-schedule'
+      path: '/spray-schedule'
       fullPath: '/mosquito-control/spray-schedule'
       preLoaderRoute: typeof MosquitoControlSprayScheduleRouteImport
-      parentRoute: typeof rootRouteImport
+      parentRoute: typeof MosquitoControlRoute
     }
     '/mosquito-control/spray-notice': {
       id: '/mosquito-control/spray-notice'
-      path: '/mosquito-control/spray-notice'
+      path: '/spray-notice'
       fullPath: '/mosquito-control/spray-notice'
       preLoaderRoute: typeof MosquitoControlSprayNoticeRouteImport
-      parentRoute: typeof rootRouteImport
+      parentRoute: typeof MosquitoControlRoute
     }
     '/mosquito-control/mosquito-control-products': {
       id: '/mosquito-control/mosquito-control-products'
-      path: '/mosquito-control/mosquito-control-products'
+      path: '/mosquito-control-products'
       fullPath: '/mosquito-control/mosquito-control-products'
       preLoaderRoute: typeof MosquitoControlMosquitoControlProductsRouteImport
-      parentRoute: typeof rootRouteImport
+      parentRoute: typeof MosquitoControlRoute
     }
     '/mosquito-control/how-we-control-mosquitoes': {
       id: '/mosquito-control/how-we-control-mosquitoes'
-      path: '/mosquito-control/how-we-control-mosquitoes'
+      path: '/how-we-control-mosquitoes'
       fullPath: '/mosquito-control/how-we-control-mosquitoes'
       preLoaderRoute: typeof MosquitoControlHowWeControlMosquitoesRouteImport
-      parentRoute: typeof rootRouteImport
+      parentRoute: typeof MosquitoControlRoute
     }
     '/mosquito-control/aerial-larviciding-notice': {
       id: '/mosquito-control/aerial-larviciding-notice'
-      path: '/mosquito-control/aerial-larviciding-notice'
+      path: '/aerial-larviciding-notice'
       fullPath: '/mosquito-control/aerial-larviciding-notice'
       preLoaderRoute: typeof MosquitoControlAerialLarvicidingNoticeRouteImport
-      parentRoute: typeof rootRouteImport
+      parentRoute: typeof MosquitoControlRoute
     }
     '/job-opportunities/$postingId': {
       id: '/job-opportunities/$postingId'
@@ -559,113 +631,150 @@ declare module '@tanstack/react-router' {
     }
     '/contact/water-management-requests': {
       id: '/contact/water-management-requests'
-      path: '/contact/water-management-requests'
+      path: '/water-management-requests'
       fullPath: '/contact/water-management-requests'
       preLoaderRoute: typeof ContactWaterManagementRequestsRouteImport
-      parentRoute: typeof rootRouteImport
+      parentRoute: typeof ContactRoute
     }
     '/contact/service-request': {
       id: '/contact/service-request'
-      path: '/contact/service-request'
+      path: '/service-request'
       fullPath: '/contact/service-request'
       preLoaderRoute: typeof ContactServiceRequestRouteImport
-      parentRoute: typeof rootRouteImport
+      parentRoute: typeof ContactRoute
     }
     '/contact/request-success': {
       id: '/contact/request-success'
-      path: '/contact/request-success'
+      path: '/request-success'
       fullPath: '/contact/request-success'
       preLoaderRoute: typeof ContactRequestSuccessRouteImport
-      parentRoute: typeof rootRouteImport
+      parentRoute: typeof ContactRoute
     }
     '/contact/mosquitofish-requests': {
       id: '/contact/mosquitofish-requests'
-      path: '/contact/mosquitofish-requests'
+      path: '/mosquitofish-requests'
       fullPath: '/contact/mosquitofish-requests'
       preLoaderRoute: typeof ContactMosquitofishRequestsRouteImport
-      parentRoute: typeof rootRouteImport
+      parentRoute: typeof ContactRoute
     }
     '/contact/contact-us': {
       id: '/contact/contact-us'
-      path: '/contact/contact-us'
+      path: '/contact-us'
       fullPath: '/contact/contact-us'
       preLoaderRoute: typeof ContactContactUsRouteImport
-      parentRoute: typeof rootRouteImport
+      parentRoute: typeof ContactRoute
     }
     '/contact/adult-mosquito-requests': {
       id: '/contact/adult-mosquito-requests'
-      path: '/contact/adult-mosquito-requests'
+      path: '/adult-mosquito-requests'
       fullPath: '/contact/adult-mosquito-requests'
       preLoaderRoute: typeof ContactAdultMosquitoRequestsRouteImport
-      parentRoute: typeof rootRouteImport
+      parentRoute: typeof ContactRoute
     }
     '/about/mosquito-control-products': {
       id: '/about/mosquito-control-products'
-      path: '/about/mosquito-control-products'
+      path: '/mosquito-control-products'
       fullPath: '/about/mosquito-control-products'
       preLoaderRoute: typeof AboutMosquitoControlProductsRouteImport
-      parentRoute: typeof rootRouteImport
+      parentRoute: typeof AboutRoute
     }
     '/about/mission-statement': {
       id: '/about/mission-statement'
-      path: '/about/mission-statement'
+      path: '/mission-statement'
       fullPath: '/about/mission-statement'
       preLoaderRoute: typeof AboutMissionStatementRouteImport
-      parentRoute: typeof rootRouteImport
+      parentRoute: typeof AboutRoute
     }
     '/about/mission': {
       id: '/about/mission'
-      path: '/about/mission'
+      path: '/mission'
       fullPath: '/about/mission'
       preLoaderRoute: typeof AboutMissionRouteImport
-      parentRoute: typeof rootRouteImport
+      parentRoute: typeof AboutRoute
     }
     '/about/leadership': {
       id: '/about/leadership'
-      path: '/about/leadership'
+      path: '/leadership'
       fullPath: '/about/leadership'
       preLoaderRoute: typeof AboutLeadershipRouteImport
-      parentRoute: typeof rootRouteImport
+      parentRoute: typeof AboutRoute
     }
     '/about/how-we-control-mosquitoes': {
       id: '/about/how-we-control-mosquitoes'
-      path: '/about/how-we-control-mosquitoes'
+      path: '/how-we-control-mosquitoes'
       fullPath: '/about/how-we-control-mosquitoes'
       preLoaderRoute: typeof AboutHowWeControlMosquitoesRouteImport
-      parentRoute: typeof rootRouteImport
+      parentRoute: typeof AboutRoute
     }
     '/about/job-opportunities/': {
       id: '/about/job-opportunities/'
-      path: '/about/job-opportunities'
+      path: '/job-opportunities'
       fullPath: '/about/job-opportunities/'
       preLoaderRoute: typeof AboutJobOpportunitiesIndexRouteImport
-      parentRoute: typeof rootRouteImport
+      parentRoute: typeof AboutRoute
     }
     '/about/job-opportunities/$postingId': {
       id: '/about/job-opportunities/$postingId'
-      path: '/about/job-opportunities/$postingId'
+      path: '/job-opportunities/$postingId'
       fullPath: '/about/job-opportunities/$postingId'
       preLoaderRoute: typeof AboutJobOpportunitiesPostingIdRouteImport
-      parentRoute: typeof rootRouteImport
+      parentRoute: typeof AboutRoute
     }
   }
 }
 
-const rootRouteChildren: RootRouteChildren = {
-  IndexRoute: IndexRoute,
-  SprayScheduleRoute: SprayScheduleRoute,
+interface AboutRouteChildren {
+  AboutHowWeControlMosquitoesRoute: typeof AboutHowWeControlMosquitoesRoute
+  AboutLeadershipRoute: typeof AboutLeadershipRoute
+  AboutMissionRoute: typeof AboutMissionRoute
+  AboutMissionStatementRoute: typeof AboutMissionStatementRoute
+  AboutMosquitoControlProductsRoute: typeof AboutMosquitoControlProductsRoute
+  AboutJobOpportunitiesPostingIdRoute: typeof AboutJobOpportunitiesPostingIdRoute
+  AboutJobOpportunitiesIndexRoute: typeof AboutJobOpportunitiesIndexRoute
+}
+
+const AboutRouteChildren: AboutRouteChildren = {
   AboutHowWeControlMosquitoesRoute: AboutHowWeControlMosquitoesRoute,
   AboutLeadershipRoute: AboutLeadershipRoute,
   AboutMissionRoute: AboutMissionRoute,
   AboutMissionStatementRoute: AboutMissionStatementRoute,
   AboutMosquitoControlProductsRoute: AboutMosquitoControlProductsRoute,
+  AboutJobOpportunitiesPostingIdRoute: AboutJobOpportunitiesPostingIdRoute,
+  AboutJobOpportunitiesIndexRoute: AboutJobOpportunitiesIndexRoute,
+}
+
+const AboutRouteWithChildren = AboutRoute._addFileChildren(AboutRouteChildren)
+
+interface ContactRouteChildren {
+  ContactAdultMosquitoRequestsRoute: typeof ContactAdultMosquitoRequestsRoute
+  ContactContactUsRoute: typeof ContactContactUsRoute
+  ContactMosquitofishRequestsRoute: typeof ContactMosquitofishRequestsRoute
+  ContactRequestSuccessRoute: typeof ContactRequestSuccessRoute
+  ContactServiceRequestRoute: typeof ContactServiceRequestRoute
+  ContactWaterManagementRequestsRoute: typeof ContactWaterManagementRequestsRoute
+}
+
+const ContactRouteChildren: ContactRouteChildren = {
   ContactAdultMosquitoRequestsRoute: ContactAdultMosquitoRequestsRoute,
   ContactContactUsRoute: ContactContactUsRoute,
   ContactMosquitofishRequestsRoute: ContactMosquitofishRequestsRoute,
   ContactRequestSuccessRoute: ContactRequestSuccessRoute,
   ContactServiceRequestRoute: ContactServiceRequestRoute,
   ContactWaterManagementRequestsRoute: ContactWaterManagementRequestsRoute,
-  JobOpportunitiesPostingIdRoute: JobOpportunitiesPostingIdRoute,
+}
+
+const ContactRouteWithChildren =
+  ContactRoute._addFileChildren(ContactRouteChildren)
+
+interface MosquitoControlRouteChildren {
+  MosquitoControlAerialLarvicidingNoticeRoute: typeof MosquitoControlAerialLarvicidingNoticeRoute
+  MosquitoControlHowWeControlMosquitoesRoute: typeof MosquitoControlHowWeControlMosquitoesRoute
+  MosquitoControlMosquitoControlProductsRoute: typeof MosquitoControlMosquitoControlProductsRoute
+  MosquitoControlSprayNoticeRoute: typeof MosquitoControlSprayNoticeRoute
+  MosquitoControlSprayScheduleRoute: typeof MosquitoControlSprayScheduleRoute
+}
+
+const MosquitoControlRouteChildren: MosquitoControlRouteChildren = {
   MosquitoControlAerialLarvicidingNoticeRoute:
     MosquitoControlAerialLarvicidingNoticeRoute,
   MosquitoControlHowWeControlMosquitoesRoute:
@@ -674,20 +783,59 @@ const rootRouteChildren: RootRouteChildren = {
     MosquitoControlMosquitoControlProductsRoute,
   MosquitoControlSprayNoticeRoute: MosquitoControlSprayNoticeRoute,
   MosquitoControlSprayScheduleRoute: MosquitoControlSprayScheduleRoute,
+}
+
+const MosquitoControlRouteWithChildren = MosquitoControlRoute._addFileChildren(
+  MosquitoControlRouteChildren,
+)
+
+interface MosquitoSurveillanceRouteChildren {
+  MosquitoSurveillanceMosquitoSourceChecklistRoute: typeof MosquitoSurveillanceMosquitoSourceChecklistRoute
+  MosquitoSurveillanceMunicipalPacketRoute: typeof MosquitoSurveillanceMunicipalPacketRoute
+  MosquitoSurveillanceWeeklyActivityRoute: typeof MosquitoSurveillanceWeeklyActivityRoute
+}
+
+const MosquitoSurveillanceRouteChildren: MosquitoSurveillanceRouteChildren = {
   MosquitoSurveillanceMosquitoSourceChecklistRoute:
     MosquitoSurveillanceMosquitoSourceChecklistRoute,
   MosquitoSurveillanceMunicipalPacketRoute:
     MosquitoSurveillanceMunicipalPacketRoute,
   MosquitoSurveillanceWeeklyActivityRoute:
     MosquitoSurveillanceWeeklyActivityRoute,
+}
+
+const MosquitoSurveillanceRouteWithChildren =
+  MosquitoSurveillanceRoute._addFileChildren(MosquitoSurveillanceRouteChildren)
+
+interface NoticesRouteChildren {
+  NoticesNoticeIdRoute: typeof NoticesNoticeIdRoute
+  NoticesArchiveRoute: typeof NoticesArchiveRoute
+  NoticesMeetingsRoute: typeof NoticesMeetingsRoute
+  NoticesTransparencyRoute: typeof NoticesTransparencyRoute
+  NoticesIndexRoute: typeof NoticesIndexRoute
+}
+
+const NoticesRouteChildren: NoticesRouteChildren = {
   NoticesNoticeIdRoute: NoticesNoticeIdRoute,
   NoticesArchiveRoute: NoticesArchiveRoute,
   NoticesMeetingsRoute: NoticesMeetingsRoute,
   NoticesTransparencyRoute: NoticesTransparencyRoute,
-  JobOpportunitiesIndexRoute: JobOpportunitiesIndexRoute,
   NoticesIndexRoute: NoticesIndexRoute,
-  AboutJobOpportunitiesPostingIdRoute: AboutJobOpportunitiesPostingIdRoute,
-  AboutJobOpportunitiesIndexRoute: AboutJobOpportunitiesIndexRoute,
+}
+
+const NoticesRouteWithChildren =
+  NoticesRoute._addFileChildren(NoticesRouteChildren)
+
+const rootRouteChildren: RootRouteChildren = {
+  IndexRoute: IndexRoute,
+  AboutRoute: AboutRouteWithChildren,
+  ContactRoute: ContactRouteWithChildren,
+  MosquitoControlRoute: MosquitoControlRouteWithChildren,
+  MosquitoSurveillanceRoute: MosquitoSurveillanceRouteWithChildren,
+  NoticesRoute: NoticesRouteWithChildren,
+  SprayScheduleRoute: SprayScheduleRoute,
+  JobOpportunitiesPostingIdRoute: JobOpportunitiesPostingIdRoute,
+  JobOpportunitiesIndexRoute: JobOpportunitiesIndexRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/apps/public/src/routes/about.tsx
+++ b/apps/public/src/routes/about.tsx
@@ -1,0 +1,44 @@
+import {
+	SectionLayout,
+	SectionSidebar,
+} from "@mcmec/ui/components/section-sidebar";
+import {
+	createFileRoute,
+	Link,
+	Outlet,
+	useLocation,
+} from "@tanstack/react-router";
+
+export const Route = createFileRoute("/about")({
+	component: AboutLayout,
+});
+
+const aboutLinks = [
+	{ label: "Mission Statement", href: "/about/mission-statement" },
+	{ label: "Leadership", href: "/about/leadership" },
+];
+
+function AboutLayout() {
+	const location = useLocation();
+
+	return (
+		<SectionLayout
+			sidebar={
+				<SectionSidebar
+					links={aboutLinks.map((link) => ({
+						...link,
+						isActive: location.pathname === link.href,
+					}))}
+					renderLink={(link, className) => (
+						<Link className={className} to={link.href}>
+							{link.label}
+						</Link>
+					)}
+					title="About"
+				/>
+			}
+		>
+			<Outlet />
+		</SectionLayout>
+	);
+}

--- a/apps/public/src/routes/about/leadership.tsx
+++ b/apps/public/src/routes/about/leadership.tsx
@@ -49,7 +49,7 @@ const commissioners: Commissioner[] = [
 
 function RouteComponent() {
 	return (
-		<article className="prose lg:prose-xl max-w-none">
+		<article className="prose lg:prose-base max-w-none">
 			<h1>Leadership</h1>
 			<p>
 				The Middlesex County Mosquito Extermination Commission (MCMEC) is led by

--- a/apps/public/src/routes/about/mission-statement.tsx
+++ b/apps/public/src/routes/about/mission-statement.tsx
@@ -7,7 +7,7 @@ export const Route = createFileRoute("/about/mission-statement")({
 
 function RouteComponent() {
 	return (
-		<article className="prose lg:prose-xl max-w-none">
+		<article className="prose lg:prose-base max-w-none">
 			<h1>Mission Statement</h1>
 			<p>
 				<img

--- a/apps/public/src/routes/contact.tsx
+++ b/apps/public/src/routes/contact.tsx
@@ -1,0 +1,44 @@
+import {
+	SectionLayout,
+	SectionSidebar,
+} from "@mcmec/ui/components/section-sidebar";
+import {
+	createFileRoute,
+	Link,
+	Outlet,
+	useLocation,
+} from "@tanstack/react-router";
+
+export const Route = createFileRoute("/contact")({
+	component: ContactLayout,
+});
+
+const contactLinks = [
+	{ label: "Service Requests", href: "/contact/service-request" },
+	{ label: "Contact Us", href: "/contact/contact-us" },
+];
+
+function ContactLayout() {
+	const location = useLocation();
+
+	return (
+		<SectionLayout
+			sidebar={
+				<SectionSidebar
+					links={contactLinks.map((link) => ({
+						...link,
+						isActive: location.pathname === link.href,
+					}))}
+					renderLink={(link, className) => (
+						<Link className={className} to={link.href}>
+							{link.label}
+						</Link>
+					)}
+					title="Contact"
+				/>
+			}
+		>
+			<Outlet />
+		</SectionLayout>
+	);
+}

--- a/apps/public/src/routes/contact/adult-mosquito-requests.tsx
+++ b/apps/public/src/routes/contact/adult-mosquito-requests.tsx
@@ -120,7 +120,7 @@ function RouteComponent() {
 
 	return (
 		<div className="flex flex-col gap-4">
-			<article className="prose lg:prose-xl max-w-none">
+			<article className="prose lg:prose-base max-w-none">
 				<h1>Adult Mosquito Nuisance Request</h1>
 				<p>
 					Use this form to report a high number of adult mosquitoes on your

--- a/apps/public/src/routes/contact/contact-us.tsx
+++ b/apps/public/src/routes/contact/contact-us.tsx
@@ -77,7 +77,7 @@ function RouteComponent() {
 
 	return (
 		<div className="mx-auto w-full max-w-7xl p-4">
-			<article className="prose lg:prose-xl max-w-none">
+			<article className="prose lg:prose-base max-w-none">
 				<h1>Contact Us</h1>
 				<p>
 					The Middlesex County Mosquito Extermination Commission is dedicated to

--- a/apps/public/src/routes/contact/mosquitofish-requests.tsx
+++ b/apps/public/src/routes/contact/mosquitofish-requests.tsx
@@ -111,7 +111,7 @@ function RouteComponent() {
 
 	return (
 		<div className="flex flex-col gap-4">
-			<article className="prose lg:prose-xl max-w-none">
+			<article className="prose lg:prose-base max-w-none">
 				<h1>Mosquitofish Request</h1>
 				<p>
 					Mosquitofish are small fish that feed on mosquito larvae and can be an

--- a/apps/public/src/routes/contact/request-success.tsx
+++ b/apps/public/src/routes/contact/request-success.tsx
@@ -10,7 +10,7 @@ function RouteComponent() {
 	const navigate = Route.useNavigate();
 	return (
 		<div className="flex flex-col gap-4">
-			<article className="prose lg:prose-xl max-w-none">
+			<article className="prose lg:prose-base max-w-none">
 				<h1>Request Submitted Successfully!</h1>
 				<p>
 					Thank you for submitting your request. Your request has been forwarded

--- a/apps/public/src/routes/contact/service-request.tsx
+++ b/apps/public/src/routes/contact/service-request.tsx
@@ -36,7 +36,7 @@ const options: Array<ServiceRequestOption> = [
 function RouteComponent() {
 	return (
 		<div className="mx-auto w-full max-w-7xl p-4">
-			<article className="prose lg:prose-xl max-w-none">
+			<article className="prose lg:prose-base max-w-none">
 				<h1>Service Request</h1>
 				<p>
 					Residents can submit an official service request through this page.

--- a/apps/public/src/routes/contact/water-management-requests.tsx
+++ b/apps/public/src/routes/contact/water-management-requests.tsx
@@ -115,7 +115,7 @@ function RouteComponent() {
 
 	return (
 		<div className="flex flex-col gap-4">
-			<article className="prose lg:prose-xl max-w-none">
+			<article className="prose lg:prose-base max-w-none">
 				<h1>Water Management Request</h1>
 				<p>
 					Please use this form to report significant areas of blocked waterways,

--- a/apps/public/src/routes/index.tsx
+++ b/apps/public/src/routes/index.tsx
@@ -1,8 +1,14 @@
 import { hero, heroMobile } from "@mcmec/lib/constants/assets";
 import { useIsMobile } from "@mcmec/ui/hooks/use-mobile";
-import { cn } from "@mcmec/ui/lib/utils";
-import { createFileRoute } from "@tanstack/react-router";
-import { ConciergeBell, Newspaper, Users } from "lucide-react";
+import { createFileRoute, Link } from "@tanstack/react-router";
+import {
+	CalendarDays,
+	ConciergeBell,
+	FileText,
+	Info,
+	Newspaper,
+	Users,
+} from "lucide-react";
 
 export const Route = createFileRoute("/")({
 	component: RouteComponent,
@@ -10,126 +16,118 @@ export const Route = createFileRoute("/")({
 
 function RouteComponent() {
 	const isMobile = useIsMobile();
-	const navigate = Route.useNavigate();
 
 	return (
 		<div className="-my-8 w-full">
-			{/* h-[calc(100vh-152px)] = 100vh - navbar(~120px) - sliver(32px) */}
-			<div className="relative h-[calc(100vh-152px)] w-full overflow-hidden">
+			{/* Hero Banner */}
+			<div className="relative h-[60vh] min-h-80 w-full overflow-hidden">
 				<img
 					alt="Woodbridge River cleanup project"
 					className="absolute inset-0 h-full w-full object-cover"
 					fetchPriority="high"
 					src={isMobile ? heroMobile : hero}
 				/>
-
-				{/* Dark gradient overlay */}
-				<div className="absolute inset-0 bg-linear-to-r from-black/80 via-black/40 to-transparent" />
-
-				{/* Bottom gradient for smooth transition */}
-				<div className="absolute inset-x-0 bottom-0 h-32 bg-linear-to-t from-black/60 to-transparent" />
-
-				{/* Content Centering Wrapper */}
-				<div className="absolute inset-0 flex flex-col gap-8 p-6 md:p-12">
-					<GlassCard className="max-w-xl">
-						<h2
-							className={cn(
-								"mb-4 border-white/20 border-b-2 pb-2 font-semibold leading-snug tracking-tight",
-								isMobile ? "text-2xl" : "text-3xl",
-							)}
-						>
+				<div className="absolute inset-0 bg-linear-to-r from-primary/70 via-primary/40 to-transparent" />
+				<div className="absolute inset-0 flex items-center">
+					<div className="mx-auto w-full max-w-7xl px-6 md:px-12">
+						<h1 className="max-w-2xl font-bold text-2xl text-white leading-tight tracking-tight md:text-4xl">
 							Middlesex County Mosquito Extermination Commission
-						</h2>
-						<p
-							className={cn(
-								"font-light italic leading-tighter tracking-wide",
-								isMobile ? "text-lg" : "text-xl",
-							)}
-						>
+						</h1>
+						<p className="mt-3 max-w-xl text-base text-white/90 md:text-lg">
 							Protecting the health and comfort of Middlesex County residents
 							and visitors since 1914.
 						</p>
-					</GlassCard>
-					<GlassCard className="flex max-w-xl flex-col items-center">
-						<h2
-							className={cn(
-								"mb-4 border-white/20 border-b-2 pb-2 text-center font-semibold leading-snug tracking-tight",
-								isMobile ? "text-2xl" : "text-3xl",
-							)}
-						>
-							How Can We Help You Today?
-						</h2>
-						<div
-							className={cn(
-								"flex flex-wrap",
-								isMobile ? "w-full flex-col gap-2" : "flex-row gap-4",
-							)}
-						>
-							<GlassButton
-								icon={<ConciergeBell />}
-								label="Request Service"
-								onClick={() => {
-									navigate({ to: "/contact/service-request" });
-								}}
-							/>
-							<GlassButton
-								icon={<Newspaper />}
-								label="Public Notices"
-								onClick={() => {
-									navigate({ to: "/notices" });
-								}}
-							/>
-							<GlassButton
-								icon={<Users />}
-								label="Public Meetings"
-								onClick={() => {
-									navigate({ to: "/notices/meetings" });
-								}}
-							/>
-						</div>
-					</GlassCard>
+					</div>
 				</div>
 			</div>
+
+			{/* Quick Actions */}
+			<section className="bg-background py-10 md:py-14">
+				<div className="mx-auto max-w-7xl px-6 md:px-12">
+					<h2 className="mb-6 text-center font-semibold text-foreground text-lg md:text-xl">
+						How Can We Help You Today?
+					</h2>
+					<div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+						<ActionCard
+							description="Report a mosquito problem or request mosquitofish."
+							href="/contact/service-request"
+							icon={<ConciergeBell className="size-6 text-primary" />}
+							title="Request Service"
+						/>
+						<ActionCard
+							description="View current legal notices and announcements."
+							href="/notices"
+							icon={<Newspaper className="size-6 text-primary" />}
+							title="Public Notices"
+						/>
+						<ActionCard
+							description="Meeting schedules, agendas, and minutes."
+							href="/notices/meetings"
+							icon={<Users className="size-6 text-primary" />}
+							title="Public Meetings"
+						/>
+						<ActionCard
+							description="View upcoming mosquito spray missions."
+							href="/mosquito-control/spray-schedule"
+							icon={<CalendarDays className="size-6 text-primary" />}
+							title="Spray Schedule"
+						/>
+						<ActionCard
+							description="Weekly mosquito activity reports for the county."
+							href="/mosquito-surveillance/weekly-activity"
+							icon={<FileText className="size-6 text-primary" />}
+							title="Weekly Mosquito Activity"
+						/>
+						<ActionCard
+							description="Tips on mosquito protection and prevention."
+							external
+							href="https://middlesexmosquito.sharepoint.com/:b:/g/IQCLzJFwXLQLSaGsaq3XvsZeAUmMrM-lZmc8Bg5lBTX4MIE?e=LJshK5"
+							icon={<Info className="size-6 text-primary" />}
+							title="Mosquito Fact Sheet"
+						/>
+					</div>
+				</div>
+			</section>
 		</div>
 	);
 }
 
-interface GlassCardProps {
-	className?: string;
-	children: React.ReactNode;
-}
-function GlassCard({ children, className }: GlassCardProps) {
-	return (
-		<div
-			className={`max-h-[90%] w-full overflow-y-auto rounded-xl border border-white/20 bg-black/30 p-6 text-white shadow-2xl backdrop-blur-md md:ml-12 md:p-10 ${className}`}
-		>
-			{children}
-		</div>
-	);
-}
+function ActionCard({
+	title,
+	description,
+	icon,
+	href,
+	external,
+}: {
+	title: string;
+	description: string;
+	icon: React.ReactNode;
+	href: string;
+	external?: boolean;
+}) {
+	const className =
+		"flex flex-col gap-3 rounded-lg border bg-card p-6 shadow-sm transition-shadow hover:shadow-md";
 
-interface GlassButtonProps {
-	icon?: React.ReactNode;
-	label: string;
-	onClick: () => void;
-}
-function GlassButton({ label, icon, onClick }: GlassButtonProps) {
-	const isMobile = useIsMobile();
+	if (external) {
+		return (
+			<a
+				className={className}
+				href={href}
+				rel="noopener noreferrer"
+				target="_blank"
+			>
+				{icon}
+				<h3 className="font-semibold text-base text-foreground">{title}</h3>
+				<p className="text-muted-foreground text-sm">{description}</p>
+			</a>
+		);
+	}
+
 	return (
-		<button
-			className={cn(
-				"flex gap-2 rounded-xl border border-white/20 bg-black/30 p-6 backdrop-blur-md transition-all duration-200 ease-linear hover:scale-115 hover:bg-black/40",
-				isMobile
-					? "h-8 w-full flex-row-reverse items-center justify-between"
-					: "w-36 flex-col items-center",
-			)}
-			onClick={onClick}
-			type="button"
-		>
+		<Link className={className} to={href}>
 			{icon}
-			<span className="font-light text-lg uppercase tracking-wide hover:underline">
-				{label}
-			</span>
-		</button>
+			<h3 className="font-semibold text-base text-foreground">{title}</h3>
+			<p className="text-muted-foreground text-sm">{description}</p>
+		</Link>
 	);
 }

--- a/apps/public/src/routes/job-opportunities/$postingId.tsx
+++ b/apps/public/src/routes/job-opportunities/$postingId.tsx
@@ -37,7 +37,7 @@ function RouteComponent() {
 				</Button>
 			</div>
 
-			<article className="prose lg:prose-xl max-w-none">
+			<article className="prose lg:prose-base max-w-none">
 				<h1>{posting.title}</h1>
 				<p className="text-muted-foreground">
 					{posting.published_at && (

--- a/apps/public/src/routes/job-opportunities/index.tsx
+++ b/apps/public/src/routes/job-opportunities/index.tsx
@@ -23,7 +23,7 @@ function RouteComponent() {
 
 	return (
 		<div className="flex flex-col gap-4">
-			<article className="prose lg:prose-xl mb-8 max-w-none">
+			<article className="prose lg:prose-base mb-8 max-w-none">
 				<h1>Job Opportunities</h1>
 				<p>
 					The Middlesex County Mosquito Extermination Commission is an equal

--- a/apps/public/src/routes/mosquito-control.tsx
+++ b/apps/public/src/routes/mosquito-control.tsx
@@ -1,0 +1,56 @@
+import {
+	SectionLayout,
+	SectionSidebar,
+} from "@mcmec/ui/components/section-sidebar";
+import {
+	createFileRoute,
+	Link,
+	Outlet,
+	useLocation,
+} from "@tanstack/react-router";
+
+export const Route = createFileRoute("/mosquito-control")({
+	component: MosquitoControlLayout,
+});
+
+const mosquitoControlLinks = [
+	{
+		label: "How We Control Mosquitoes",
+		href: "/mosquito-control/how-we-control-mosquitoes",
+	},
+	{
+		label: "Mosquito Control Products",
+		href: "/mosquito-control/mosquito-control-products",
+	},
+	{ label: "Spray Schedule", href: "/mosquito-control/spray-schedule" },
+	{ label: "Spray Notice", href: "/mosquito-control/spray-notice" },
+	{
+		label: "Aerial Larviciding Notice",
+		href: "/mosquito-control/aerial-larviciding-notice",
+	},
+];
+
+function MosquitoControlLayout() {
+	const location = useLocation();
+
+	return (
+		<SectionLayout
+			sidebar={
+				<SectionSidebar
+					links={mosquitoControlLinks.map((link) => ({
+						...link,
+						isActive: location.pathname === link.href,
+					}))}
+					renderLink={(link, className) => (
+						<Link className={className} to={link.href}>
+							{link.label}
+						</Link>
+					)}
+					title="Mosquito Control"
+				/>
+			}
+		>
+			<Outlet />
+		</SectionLayout>
+	);
+}

--- a/apps/public/src/routes/mosquito-control/aerial-larviciding-notice.tsx
+++ b/apps/public/src/routes/mosquito-control/aerial-larviciding-notice.tsx
@@ -8,7 +8,7 @@ export const Route = createFileRoute(
 
 function RouteComponent() {
 	return (
-		<article className="prose lg:prose-xl max-w-none">
+		<article className="prose lg:prose-base max-w-none">
 			<h1>Aerial Larviciding Notice</h1>
 			<p>This page is under construction. Please check back soon.</p>
 		</article>

--- a/apps/public/src/routes/mosquito-control/how-we-control-mosquitoes.tsx
+++ b/apps/public/src/routes/mosquito-control/how-we-control-mosquitoes.tsx
@@ -8,7 +8,7 @@ export const Route = createFileRoute(
 
 function RouteComponent() {
 	return (
-		<article className="prose lg:prose-xl max-w-none">
+		<article className="prose lg:prose-base max-w-none">
 			<h1>How We Control Mosquitoes</h1>
 			<h2>Integrated Mosquito Management</h2>
 			<p>

--- a/apps/public/src/routes/mosquito-control/mosquito-control-products.tsx
+++ b/apps/public/src/routes/mosquito-control/mosquito-control-products.tsx
@@ -32,7 +32,7 @@ function RouteComponent() {
 
 	return (
 		<div className="flex flex-col gap-4">
-			<article className="prose lg:prose-xl max-w-none">
+			<article className="prose lg:prose-base max-w-none">
 				<h1>Commonly Used Mosquito Control Products</h1>
 				<p>
 					The Commission uses insecticides with low environmental risk for

--- a/apps/public/src/routes/mosquito-control/spray-notice.tsx
+++ b/apps/public/src/routes/mosquito-control/spray-notice.tsx
@@ -6,7 +6,7 @@ export const Route = createFileRoute("/mosquito-control/spray-notice")({
 
 function RouteComponent() {
 	return (
-		<article className="prose lg:prose-xl max-w-none">
+		<article className="prose lg:prose-base max-w-none">
 			<h1>Public Notice for Adult Mosquito Control Treatment</h1>
 			<p>This page is under construction. Please check back soon.</p>
 		</article>

--- a/apps/public/src/routes/mosquito-control/spray-schedule.tsx
+++ b/apps/public/src/routes/mosquito-control/spray-schedule.tsx
@@ -55,7 +55,7 @@ function RouteComponent() {
 
 	return (
 		<div className="flex flex-col gap-6">
-			<article className="prose lg:prose-xl max-w-none">
+			<article className="prose lg:prose-base max-w-none">
 				<h1>Mosquito Spray Schedule</h1>
 				<p>
 					View upcoming and past mosquito spray missions conducted by the

--- a/apps/public/src/routes/mosquito-surveillance.tsx
+++ b/apps/public/src/routes/mosquito-surveillance.tsx
@@ -1,0 +1,54 @@
+import {
+	SectionLayout,
+	SectionSidebar,
+} from "@mcmec/ui/components/section-sidebar";
+import {
+	createFileRoute,
+	Link,
+	Outlet,
+	useLocation,
+} from "@tanstack/react-router";
+
+export const Route = createFileRoute("/mosquito-surveillance")({
+	component: MosquitoSurveillanceLayout,
+});
+
+const mosquitoSurveillanceLinks = [
+	{
+		label: "Weekly Mosquito Activity",
+		href: "/mosquito-surveillance/weekly-activity",
+	},
+	{
+		label: "Mosquito Source Checklist",
+		href: "/mosquito-surveillance/mosquito-source-checklist",
+	},
+	{
+		label: "Municipal Packet",
+		href: "/mosquito-surveillance/municipal-packet",
+	},
+];
+
+function MosquitoSurveillanceLayout() {
+	const location = useLocation();
+
+	return (
+		<SectionLayout
+			sidebar={
+				<SectionSidebar
+					links={mosquitoSurveillanceLinks.map((link) => ({
+						...link,
+						isActive: location.pathname === link.href,
+					}))}
+					renderLink={(link, className) => (
+						<Link className={className} to={link.href}>
+							{link.label}
+						</Link>
+					)}
+					title="Mosquito Surveillance"
+				/>
+			}
+		>
+			<Outlet />
+		</SectionLayout>
+	);
+}

--- a/apps/public/src/routes/mosquito-surveillance/mosquito-source-checklist.tsx
+++ b/apps/public/src/routes/mosquito-surveillance/mosquito-source-checklist.tsx
@@ -8,7 +8,7 @@ export const Route = createFileRoute(
 
 function RouteComponent() {
 	return (
-		<article className="prose lg:prose-xl max-w-none">
+		<article className="prose lg:prose-base max-w-none">
 			<h1>Mosquito Source Checklist</h1>
 			<p>This page is under construction. Please check back soon.</p>
 		</article>

--- a/apps/public/src/routes/mosquito-surveillance/municipal-packet.tsx
+++ b/apps/public/src/routes/mosquito-surveillance/municipal-packet.tsx
@@ -8,7 +8,7 @@ export const Route = createFileRoute("/mosquito-surveillance/municipal-packet")(
 
 function RouteComponent() {
 	return (
-		<article className="prose lg:prose-xl max-w-none">
+		<article className="prose lg:prose-base max-w-none">
 			<h1>Municipal Packet</h1>
 			<p>This page is under construction. Please check back soon.</p>
 		</article>

--- a/apps/public/src/routes/mosquito-surveillance/weekly-activity.tsx
+++ b/apps/public/src/routes/mosquito-surveillance/weekly-activity.tsx
@@ -32,7 +32,7 @@ function RouteComponent() {
 
 	if (chartData.length === 0) {
 		return (
-			<article className="prose lg:prose-xl max-w-none">
+			<article className="prose lg:prose-base max-w-none">
 				<h1>Weekly Mosquito Activity</h1>
 				<p>
 					No mosquito activity data is currently available. Please check back

--- a/apps/public/src/routes/notices.tsx
+++ b/apps/public/src/routes/notices.tsx
@@ -1,0 +1,46 @@
+import {
+	SectionLayout,
+	SectionSidebar,
+} from "@mcmec/ui/components/section-sidebar";
+import {
+	createFileRoute,
+	Link,
+	Outlet,
+	useLocation,
+} from "@tanstack/react-router";
+
+export const Route = createFileRoute("/notices")({
+	component: NoticesLayout,
+});
+
+const noticesLinks = [
+	{ label: "Legal Notices", href: "/notices" },
+	{ label: "Public Meetings", href: "/notices/meetings" },
+	{ label: "Archived Notices", href: "/notices/archive" },
+	{ label: "Transparency", href: "/notices/transparency" },
+];
+
+function NoticesLayout() {
+	const location = useLocation();
+
+	return (
+		<SectionLayout
+			sidebar={
+				<SectionSidebar
+					links={noticesLinks.map((link) => ({
+						...link,
+						isActive: location.pathname === link.href,
+					}))}
+					renderLink={(link, className) => (
+						<Link className={className} to={link.href}>
+							{link.label}
+						</Link>
+					)}
+					title="Public Notices"
+				/>
+			}
+		>
+			<Outlet />
+		</SectionLayout>
+	);
+}

--- a/apps/public/src/routes/notices/$noticeId.tsx
+++ b/apps/public/src/routes/notices/$noticeId.tsx
@@ -89,7 +89,7 @@ function RouteComponent() {
 				/>
 			</div>
 
-			<article className="prose lg:prose-xl max-w-none">
+			<article className="prose lg:prose-base max-w-none">
 				<h2>{title}</h2>
 				<div className="flex flex-row items-center gap-2">
 					<Label>Status: </Label>
@@ -103,7 +103,7 @@ function RouteComponent() {
 				<h3>Notice Date: {formatDate(notice_date)}</h3>
 				<TiptapRenderer content={content} />
 			</article>
-			<div className="flex flex-col text-muted text-sm italic">
+			<div className="flex flex-col text-foreground/70 text-sm italic">
 				<p>Notice Type: {type}</p>
 				<p>Notice ID: {id}</p>
 				<p>

--- a/apps/public/src/routes/notices/archive.tsx
+++ b/apps/public/src/routes/notices/archive.tsx
@@ -46,7 +46,7 @@ function RouteComponent() {
 
 	return (
 		<div className="flex flex-col gap-4">
-			<article className="prose lg:prose-xl mb-8 max-w-none">
+			<article className="prose lg:prose-base mb-8 max-w-none">
 				<h1>Archived Legal Notices</h1>
 				<p>
 					This website and the public notices contained herein are maintained in

--- a/apps/public/src/routes/notices/index.tsx
+++ b/apps/public/src/routes/notices/index.tsx
@@ -46,7 +46,7 @@ function RouteComponent() {
 
 	return (
 		<div className="flex flex-col gap-4">
-			<article className="prose lg:prose-xl mb-8 max-w-none">
+			<article className="prose lg:prose-base mb-8 max-w-none">
 				<h1>Current Legal Notices</h1>
 				<p>
 					This website and the public notices contained herein are maintained in

--- a/apps/public/src/routes/notices/meetings.tsx
+++ b/apps/public/src/routes/notices/meetings.tsx
@@ -33,7 +33,7 @@ function RouteComponent() {
 
 	return (
 		<div className="flex flex-col gap-4">
-			<article className="prose lg:prose-xl mb-8 max-w-none">
+			<article className="prose lg:prose-base mb-8 max-w-none">
 				<h1>Meetings</h1>
 				<p>
 					In accordance with the New Jersey Open Public Meetings Act (N.J.S.A.

--- a/apps/public/src/routes/notices/transparency.tsx
+++ b/apps/public/src/routes/notices/transparency.tsx
@@ -49,7 +49,7 @@ function RouteComponent() {
 
 	return (
 		<div className="mx-auto max-w-4xl">
-			<article className="prose lg:prose-xl mb-8 max-w-none">
+			<article className="prose lg:prose-base mb-8 max-w-none">
 				<h1>Transparency</h1>
 				<p>
 					In compliance with N.J.S.A. 40A:5A-17.1 and L. 2011, c.167, the

--- a/packages/ui/src/blocks/mosquito-activity-chart.tsx
+++ b/packages/ui/src/blocks/mosquito-activity-chart.tsx
@@ -167,7 +167,7 @@ export function MosquitoActivityChart({
 				{description && <CardDescription>{description}</CardDescription>}
 			</CardHeader>
 			<CardContent>
-				<ChartContainer className="h-[350px] w-full" config={chartConfig}>
+				<ChartContainer className="h-55 w-full" config={chartConfig}>
 					<ComposedChart
 						data={chartData}
 						margin={{ top: 5, right: 10, left: 10, bottom: 5 }}

--- a/packages/ui/src/components/navigation-menu.tsx
+++ b/packages/ui/src/components/navigation-menu.tsx
@@ -59,7 +59,7 @@ function NavigationMenuItem({
 }
 
 const navigationMenuTriggerStyle = cva(
-  "group inline-flex h-12 w-max items-center justify-center rounded-md px-4 py-2 text-2xl text-primary-foreground font-bold uppercase tracking-wider hover:bg-accent/40 hover:text-primary-foreground focus:bg-accent/40 focus:text-primary-foreground disabled:pointer-events-none disabled:opacity-50 data-[state=open]:hover:bg-accent/40 data-[state=open]:text-primary-foreground data-[state=open]:focus:bg-accent/40 data-[state=open]:bg-accent/40 focus-visible:ring-ring/50 outline-none transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1"
+  "group inline-flex h-10 w-max items-center justify-center rounded-md px-3 py-1.5 font-semibold text-primary-foreground text-sm uppercase tracking-wide outline-none transition-[color,box-shadow] hover:bg-accent/40 hover:text-primary-foreground focus:bg-accent/40 focus:text-primary-foreground disabled:pointer-events-none disabled:opacity-50 data-[state=open]:bg-accent/40 data-[state=open]:text-primary-foreground data-[state=open]:hover:bg-accent/40 data-[state=open]:focus:bg-accent/40 focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1"
 )
 
 function NavigationMenuTrigger({

--- a/packages/ui/src/components/section-sidebar.tsx
+++ b/packages/ui/src/components/section-sidebar.tsx
@@ -1,0 +1,83 @@
+import * as React from "react";
+import { cn } from "@mcmec/ui/lib/utils";
+
+interface SectionSidebarLink {
+	label: string;
+	href: string;
+	isActive?: boolean;
+}
+
+interface SectionSidebarProps {
+	title: string;
+	links: SectionSidebarLink[];
+	className?: string;
+	renderLink?: (
+		link: SectionSidebarLink,
+		className: string,
+	) => React.ReactNode;
+}
+
+function SectionSidebar({
+	title,
+	links,
+	className,
+	renderLink,
+}: SectionSidebarProps) {
+	return (
+		<aside
+			className={cn("hidden shrink-0 md:block md:w-56", className)}
+			aria-label={`${title} section navigation`}
+		>
+			<nav>
+				<h2 className="mb-3 border-b border-primary/20 pb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+					{title}
+				</h2>
+				<ul className="flex flex-col gap-0">
+					{links.map((link) => {
+						const linkClassName = cn(
+							"block whitespace-nowrap rounded-md px-3 py-2 text-sm transition-colors",
+							link.isActive
+								? "border-l-2 border-primary bg-primary/10 font-medium text-primary"
+								: "text-muted-foreground hover:bg-muted hover:text-foreground",
+						);
+
+						return (
+							<li key={link.href}>
+								{renderLink ? (
+									renderLink(link, linkClassName)
+								) : (
+									<a href={link.href} className={linkClassName}>
+										{link.label}
+									</a>
+								)}
+							</li>
+						);
+					})}
+				</ul>
+			</nav>
+		</aside>
+	);
+}
+
+interface SectionLayoutProps {
+	sidebar: React.ReactNode;
+	children: React.ReactNode;
+	className?: string;
+}
+
+function SectionLayout({ sidebar, children, className }: SectionLayoutProps) {
+	return (
+		<div
+			className={cn(
+				"flex flex-col gap-6 md:flex-row md:gap-10",
+				className,
+			)}
+		>
+			{sidebar}
+			<div className="min-w-0 flex-1">{children}</div>
+		</div>
+	);
+}
+
+export { SectionSidebar, SectionLayout };
+export type { SectionSidebarLink, SectionSidebarProps, SectionLayoutProps };

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -1,5 +1,6 @@
 @import "tailwindcss";
 @import "tw-animate-css";
+@import url("https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100..900;1,100..900&display=swap");
 
 @source "../../../apps/**/*.{ts,tsx}";
 @source "../../../components/**/*.{ts,tsx}";
@@ -8,66 +9,62 @@
 @plugin "@tailwindcss/typography";
 
 :root {
-	--background: oklch(100% 0.00011 271.152);
+	--background: oklch(0.985 0.002 150);
 	--foreground: oklch(0.2537 0.0035 164.7797);
-	--card: oklch(0.8555 0.0035 67.7765);
+	--card: oklch(0.98 0.005 150);
 	--card-foreground: oklch(0.2537 0.0035 164.7797);
-	--popover: oklch(0.8555 0.0035 67.7765);
+	--popover: oklch(0.98 0.005 150);
 	--popover-foreground: oklch(0.2537 0.0035 164.7797);
 	--primary: oklch(0.5364 0.1457 150.5842);
 	--primary-foreground: oklch(0.9556 0.0199 112.9333);
-	--secondary: oklch(0.8176 0.1 116.5842);
+	--secondary: oklch(0.92 0.03 150);
 	--secondary-foreground: oklch(0.2537 0.0035 164.7797);
-	--muted: oklch(0.83 0.0307 164.1343);
-	--muted-foreground: oklch(0.3538 0.0069 118.171);
+	--muted: oklch(0.94 0.01 150);
+	--muted-foreground: oklch(0.45 0.02 150);
 	--accent: oklch(0.6638 0.0267 183.8599);
-	--accent-foreground: oklch(0.3394 0.0441 1.7583);
+	--accent-foreground: oklch(0.98 0.005 150);
 	--destructive: oklch(0.5046 0.2053 29.0423);
 	--destructive-foreground: oklch(0.8852 0.0042 91.4508);
-	--border: oklch(36.07% 0.06071 159.857);
-	--input: oklch(0.9329 0.0124 301.2783);
+	--border: oklch(0.8 0.02 150);
+	--input: oklch(0.92 0.01 150);
 	--ring: oklch(0.5353 0.1357 153.5529);
 	--chart-1: oklch(0.6104 0.0767 299.7335);
 	--chart-2: oklch(0.7889 0.0802 359.9375);
 	--chart-3: oklch(0.7321 0.0749 169.867);
 	--chart-4: oklch(0.854 0.0882 76.8292);
 	--chart-5: oklch(0.7857 0.0645 258.0839);
-	--sidebar: oklch(0.9427 0.0054 95.1019);
+	--sidebar: oklch(0.96 0.01 150);
 	--sidebar-foreground: oklch(0.2713 0.0023 145.5111);
 	--sidebar-primary: oklch(0.5353 0.1357 153.5529);
-	--sidebar-primary-foreground: oklch(0.8852 0.0042 91.4508);
-	--sidebar-accent: oklch(0.8114 0.0992 114.1476);
+	--sidebar-primary-foreground: oklch(0.98 0.005 150);
+	--sidebar-accent: oklch(0.92 0.03 150);
 	--sidebar-accent-foreground: oklch(0.3867 0.0191 145.1951);
-	--sidebar-border: oklch(0.7231 0.1679 137.4158);
+	--sidebar-border: oklch(0.8 0.02 150);
 	--sidebar-ring: oklch(0.5353 0.1357 153.5529);
-	--font-sans: "Arial Nova", system-ui, sans-serif;
+	--font-sans: "Roboto", system-ui, sans-serif;
 	--font-serif: "Lora", Georgia, serif;
 	--font-mono: "Fira Code", "Courier New", monospace;
-	--radius: 1.5rem;
-	--shadow-x: 2px;
-	--shadow-y: 2px;
-	--shadow-blur: 11px;
+	--radius: 0.625rem;
+	--shadow-x: 0px;
+	--shadow-y: 1px;
+	--shadow-blur: 8px;
 	--shadow-spread: 0px;
-	--shadow-opacity: 0.19;
+	--shadow-opacity: 0.12;
 	--shadow-color: #212322;
-	--shadow-2xs: 2px 2px 11px 0px hsl(150 2.9412% 13.3333% / 0.1);
-	--shadow-xs: 2px 2px 11px 0px hsl(150 2.9412% 13.3333% / 0.1);
+	--shadow-2xs: 0 1px 2px 0 hsl(150 3% 13% / 0.05);
+	--shadow-xs: 0 1px 3px 0 hsl(150 3% 13% / 0.06);
 	--shadow-sm:
-		2px 2px 11px 0px hsl(150 2.9412% 13.3333% / 0.19),
-		2px 1px 2px -1px hsl(150 2.9412% 13.3333% / 0.19);
+		0 1px 3px 0 hsl(150 3% 13% / 0.08), 0 1px 2px -1px hsl(150 3% 13% / 0.08);
 	--shadow:
-		2px 2px 11px 0px hsl(150 2.9412% 13.3333% / 0.19),
-		2px 1px 2px -1px hsl(150 2.9412% 13.3333% / 0.19);
+		0 2px 6px 0 hsl(150 3% 13% / 0.1), 0 1px 2px -1px hsl(150 3% 13% / 0.1);
 	--shadow-md:
-		2px 2px 11px 0px hsl(150 2.9412% 13.3333% / 0.19),
-		2px 2px 4px -1px hsl(150 2.9412% 13.3333% / 0.19);
+		0 4px 8px -1px hsl(150 3% 13% / 0.1), 0 2px 4px -2px hsl(150 3% 13% / 0.08);
 	--shadow-lg:
-		2px 2px 11px 0px hsl(150 2.9412% 13.3333% / 0.19),
-		2px 4px 6px -1px hsl(150 2.9412% 13.3333% / 0.19);
+		0 8px 16px -2px hsl(150 3% 13% / 0.1), 0 4px 6px -2px hsl(150 3% 13% / 0.06);
 	--shadow-xl:
-		2px 2px 11px 0px hsl(150 2.9412% 13.3333% / 0.19),
-		2px 8px 10px -1px hsl(150 2.9412% 13.3333% / 0.19);
-	--shadow-2xl: 2px 2px 11px 0px hsl(150 2.9412% 13.3333% / 0.47);
+		0 16px 32px -4px hsl(150 3% 13% / 0.1),
+		0 8px 12px -4px hsl(150 3% 13% / 0.06);
+	--shadow-2xl: 0 24px 48px -8px hsl(150 3% 13% / 0.2);
 	--tracking-normal: 0em;
 	--spacing: 0.25rem;
 }
@@ -152,5 +149,15 @@
 	}
 	body {
 		@apply bg-background text-foreground;
+	}
+	.prose p {
+		@apply my-2 leading-normal;
+	}
+	.prose ul,
+	.prose ol {
+		@apply my-2;
+	}
+	.prose li {
+		@apply my-0.5;
 	}
 }


### PR DESCRIPTION
## Summary
- **Font**: Switch to Roboto via Google Fonts as primary `--font-sans`
- **Design tokens**: Refined color palette, reduced border radius (1.5rem → 0.625rem), centered/softened shadows
- **Navbar**: Scaled down typography (text-2xl → text-sm), compacted height (h-30 → h-16), CSS-based mobile responsive (no SSR flash)
- **Home page**: Brand-green hero overlay + 6 action cards (Request Service, Public Notices, Public Meetings, Spray Schedule, Weekly Activity, Mosquito Fact Sheet)
- **Section sidebars**: New `SectionSidebar` component in `@mcmec/ui`, integrated via layout routes for About, Contact, Mosquito Control, Mosquito Surveillance, and Notices sections
- **Footer**: Expanded to 4-column grid (Agency Info, Quick Links, Public Info, Contact Us) with mobile-centered layout
- **Typography**: `prose lg:prose-xl` → `prose lg:prose-base` across all 23 route files, tighter prose `p`/`ul`/`li` spacing
- **Charts**: Reduced weekly mosquito activity chart height (350px → 220px)
- **Bug fix**: Notice detail `text-muted` → `text-foreground/70` for metadata readability

## Test plan
- [ ] Verify home page renders hero, action cards, and footer on desktop and mobile
- [ ] Verify section sidebar appears on desktop for About, Contact, Mosquito Control, Mosquito Surveillance, and Notices pages
- [ ] Verify sidebar is hidden on mobile and sheet menu works for navigation
- [ ] Verify Roboto font loads correctly
- [ ] Verify prose content is properly sized on both desktop and mobile
- [ ] Verify footer columns are centered on mobile and left-aligned on desktop
- [ ] Verify external Mosquito Fact Sheet link opens in new tab
- [ ] Run `pnpm check-types` and `pnpm build` to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)