### PR TITLE
feat: add content to under-construction public pages

### DIFF
--- a/.changeset/public-page-content.md
+++ b/.changeset/public-page-content.md
@@ -1,0 +1,6 @@
+---
+"public": patch
+"@mcmec/ui": patch
+---
+
+Add content to under-construction public pages: spray notice, aerial larviciding notice, mosquito source checklist, and municipal packet. Fix CSS @import ordering in globals.css.

--- a/apps/public/src/routes/mosquito-control/aerial-larviciding-notice.tsx
+++ b/apps/public/src/routes/mosquito-control/aerial-larviciding-notice.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, Link } from "@tanstack/react-router";
 
 export const Route = createFileRoute(
 	"/mosquito-control/aerial-larviciding-notice",
@@ -9,8 +9,82 @@ export const Route = createFileRoute(
 function RouteComponent() {
 	return (
 		<article className="prose lg:prose-base max-w-none">
-			<h1>Aerial Larviciding Notice</h1>
-			<p>This page is under construction. Please check back soon.</p>
+			<h1>Aerial Larvicide Treatment Notice</h1>
+			<p>
+				To control mosquitoes, the Middlesex County Mosquito Extermination
+				Commission routinely inspects and treats by helicopter non-residential
+				areas including marshes, wetlands and other large natural areas, which
+				are common habitats for mosquitoes. Granules containing natural bacteria
+				or chemical are dropped from a low-flying helicopter to kill mosquito
+				larvae before they grow into adult mosquitoes. Due to their size and
+				inaccessibility by ground vehicles, these areas are treated when
+				necessary pursuant to heavy rainfall or tidal events.
+			</p>
+			<p>
+				You may see our helicopter flying over residential areas. However, no
+				applications are made over residential neighborhoods. The pilot is
+				merely positioning the helicopter to approach the wetlands in nearby
+				areas.
+			</p>
+			<p>
+				To view our aerial treatment locations, please{" "}
+				<a
+					href="https://www.google.com/maps/d/u/0/viewer?mid=1405E_kiyQ4_fjzdJn9jkFzY7SQE&ll=40.43034941206448%2C-74.416975&z=11"
+					rel="noopener noreferrer"
+					target="_blank"
+				>
+					click here
+				</a>
+				.
+			</p>
+			<p>
+				<strong>PLEASE NOTE: THIS IS NOT A "SPRAYING" ACTIVITY.</strong>
+			</p>
+			<p>
+				No precautions are recommended for this treatment. Human exposure to
+				product is very minimal.
+			</p>
+
+			<h2>Method of Application</h2>
+			<p>
+				Low altitude, granular application using a helicopter over uninhabited
+				wetland areas located throughout Middlesex County.
+			</p>
+
+			<h2>Mosquito Control Products</h2>
+			<ul>
+				<li>
+					<strong>
+						<a
+							href="https://npic.orst.edu/factsheets/BTgen.pdf"
+							rel="noopener noreferrer"
+							target="_blank"
+						>
+							Bacillus thuringiensis israelensis (Bti)
+						</a>
+						:
+					</strong>{" "}
+					a biological larvicide
+				</li>
+				<li>
+					<strong>
+						<a
+							href="https://npic.orst.edu/factsheets/spinosadgen.html"
+							rel="noopener noreferrer"
+							target="_blank"
+						>
+							Spinosad
+						</a>
+						:
+					</strong>{" "}
+					a biologically derived larvicide
+				</li>
+			</ul>
+
+			<p>
+				If conditions are not ideal, treatments will not be conducted. For more
+				information, please <Link to="/contact/contact-us">contact us</Link>.
+			</p>
 		</article>
 	);
 }

--- a/apps/public/src/routes/mosquito-control/spray-notice.tsx
+++ b/apps/public/src/routes/mosquito-control/spray-notice.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, Link } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/mosquito-control/spray-notice")({
 	component: RouteComponent,
@@ -8,7 +8,159 @@ function RouteComponent() {
 	return (
 		<article className="prose lg:prose-base max-w-none">
 			<h1>Public Notice for Adult Mosquito Control Treatment</h1>
-			<p>This page is under construction. Please check back soon.</p>
+			<p>
+				In compliance with section 9.10 and 9.15 of the New Jersey Pesticide
+				Control Code (N.J.A.C. Title 7, Chapter 30), the Middlesex County
+				Mosquito Extermination Commission may be applying mosquito control
+				products for the control of adult mosquito populations on an area-wide
+				basis, as needed, throughout Middlesex County during the period of May
+				1st through November 30th.
+			</p>
+			<p>
+				The mosquito control products used will be those{" "}
+				<a
+					href="https://middlesexmosquito.sharepoint.com/:b:/g/IQAdHws6ZPl5TKbUfOi7KZeVAWhhhW6vCOHOhHqbNgJW5_I?e=l3TjE4"
+					rel="noopener noreferrer"
+					target="_blank"
+				>
+					recommended by the New Jersey Agricultural Experiment Station (NJAES),
+					Rutgers University
+				</a>{" "}
+				for the control of adult mosquitoes which include:
+			</p>
+			<ul>
+				<li>
+					Malathion (Fyfanon® ULV, EPA Reg#67760-34) (
+					<a
+						href="https://middlesexmosquito.sharepoint.com/:b:/g/IQCAAHgu9bwtSJILsQLUPrE5AZl4XQ1wtcC8JiOnbpIIluo?e=1e5AmF"
+						rel="noopener noreferrer"
+						target="_blank"
+					>
+						Fact Sheet
+					</a>
+					)
+				</li>
+				<li>
+					Etofenprox (Zenivex® E4 RTU, EPA Reg#2724-807; Zenivex® E20, EPA
+					Reg#2724-791) (
+					<a
+						href="https://middlesexmosquito.sharepoint.com/:b:/g/IQA8WAM64HkzSYZ8dAej33eKAQFheJOEA3HntjhHQMKkLSE?e=gc2J92"
+						rel="noopener noreferrer"
+						target="_blank"
+					>
+						Fact Sheet
+					</a>
+					)
+				</li>
+				<li>
+					Prallethrin - Sumithrin (Duet™ Dual-Action Adulticide, EPA
+					Reg#1021-1795-8329) (
+					<a
+						href="https://middlesexmosquito.sharepoint.com/:b:/g/IQAGYFoWpJj2S7KH16-KTOzsARkyuLQu0PRDd0Ab-zylXbs?e=0iPEHS"
+						rel="noopener noreferrer"
+						target="_blank"
+					>
+						Fact Sheet
+					</a>
+					)
+				</li>
+				<li>
+					Deltamethrin (DeltaGard® EPA, Reg#432-1534) (
+					<a
+						href="https://middlesexmosquito.sharepoint.com/:b:/g/IQAAsUz6I6tBTas8NDIz7MybAWOGmKjtQVSONRwe5mr5tDE?e=TIhjep"
+						rel="noopener noreferrer"
+						target="_blank"
+					>
+						Fact Sheet
+					</a>
+					)
+				</li>
+			</ul>
+			<p>
+				All applications will be according to product labeling. Products will be
+				applied from the ground by truck or handheld equipment and/or by
+				aircraft, all using low volume (LV) or ultra-low volume (ULV)
+				techniques.
+			</p>
+			<p>
+				For routine pesticide-related health inquiries, please contact the{" "}
+				<a
+					href="https://npic.orst.edu/"
+					rel="noopener noreferrer"
+					target="_blank"
+				>
+					National Pesticide Information Center
+				</a>
+				, at 1-800-858-7378. For information on pesticide regulations, pesticide
+				complaints and health referrals, contact the New Jersey Pesticide
+				Control Program at 609-984-6568. In the case of any pesticide emergency,
+				please contact the{" "}
+				<a
+					href="https://www.njpies.org/"
+					rel="noopener noreferrer"
+					target="_blank"
+				>
+					New Jersey Poison Information and Education System
+				</a>{" "}
+				at 1-800-222-1222. For the most updated information on the time and
+				location of adult mosquito control applications, please view the{" "}
+				<Link to="/mosquito-control/spray-schedule">Spray Schedule</Link> page
+				or call the Office at 732-549-0665. Upon request, the pesticide
+				applicator (MCMEC) shall provide a resident with notification at least
+				12-hours prior to the application, except for Quarantine and Disease
+				Vector Control only, when conditions necessitate pesticide applications
+				sooner than that time.
+			</p>
+			<p>
+				Remember: Mosquito control is everyone's responsibility; please do your
+				part by preventing mosquito production on your property. For more
+				information on mosquitoes and mosquito control, contact the
+				Superintendent (NJDEP CPA License #50245B), Middlesex County Mosquito
+				Extermination Commission at 732-549-0665.
+			</p>
+
+			<h2>Precautions to Reduce Exposure</h2>
+			<p>
+				In order to reduce the number of nuisance and vector mosquitoes in the
+				specified area(s), the following adult mosquito control products will be
+				applied from the ground by truck or handheld equipment and/or by
+				aircraft, all using low volume (LV) or ultra-low volume (ULV)
+				techniques. Neither the USEPA nor the NJ Department of Environmental
+				Protection (NJDEP) requires relocating or taking special precautions
+				during spraying with this product. All applications will be made
+				according to product labeling. However, to reduce exposure:
+			</p>
+			<ul>
+				<li>
+					Pay attention to notices about mosquito insecticide treatments found
+					through newspapers, websites, automated telephone messages or notices
+					distributed by municipal, county or state agencies.
+				</li>
+				<li>
+					Plan your activities to limit time spent outside during times of
+					possible insecticide treatments. Move your pets, their food, and water
+					dishes inside during applications. Also bring clothing and children's
+					toys inside. Stay back from application equipment, whether in use or
+					not.
+				</li>
+				<li>
+					Whenever possible, remain indoors with windows closed and with window
+					air conditioners on non-vent (closed to the outside air) and window
+					fans turned off during spraying.
+				</li>
+				<li>
+					Avoid direct contact with surfaces that are still wet from pesticide
+					spraying. Do not allow children to play in areas that have been
+					sprayed until they have completely dried (approximately one hour).
+				</li>
+				<li>
+					If you must remain outdoors, avoid eye and skin contact with the
+					spray. If you get spray in your eyes or on your skin, immediately
+					flush and rinse with water. If you believe that you have been exposed
+					to pesticide spray and have health-related questions, contact your
+					physician.
+				</li>
+			</ul>
 		</article>
 	);
 }

--- a/apps/public/src/routes/mosquito-surveillance/mosquito-source-checklist.tsx
+++ b/apps/public/src/routes/mosquito-surveillance/mosquito-source-checklist.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, Link } from "@tanstack/react-router";
 
 export const Route = createFileRoute(
 	"/mosquito-surveillance/mosquito-source-checklist",
@@ -9,8 +9,148 @@ export const Route = createFileRoute(
 function RouteComponent() {
 	return (
 		<article className="prose lg:prose-base max-w-none">
-			<h1>Mosquito Source Checklist</h1>
-			<p>This page is under construction. Please check back soon.</p>
+			<h1>Mosquito Habitat Elimination Checklist</h1>
+			<p>
+				For a printable version of this checklist, please{" "}
+				<a
+					href="https://middlesexmosquito.sharepoint.com/:b:/g/IQDU2lPjFJT1R5BYNaun8_pbAYrJW9530Xww9vCkTIyQ68Y?e=VtogKz"
+					rel="noopener noreferrer"
+					target="_blank"
+				>
+					click here
+				</a>
+				.
+			</p>
+			<p>
+				Use this checklist to find and get rid of all the standing water around
+				your home where immature mosquitoes may live.
+			</p>
+			<p>
+				Immature mosquitoes live and grow in standing water. It takes them about
+				7 days to grow and become adult mosquitoes that are ready to fly and
+				bite.
+			</p>
+
+			<h2>Common Household Items</h2>
+			<ul>
+				<li>
+					<strong>Buckets:</strong> Empty water from buckets and turn them over.
+				</li>
+				<li>
+					<strong>Garbage cans and recycling bins:</strong> Drill drainage holes
+					in the bottoms of garbage cans and bins, keep covered and dispose of
+					recycling weekly if possible.
+				</li>
+				<li>
+					<strong>Tarps, plastic bags and sheets:</strong> Keep tarps tight and
+					refit them if water collects.
+				</li>
+			</ul>
+
+			<h2>Building Structures</h2>
+			<ul>
+				<li>
+					<strong>Gutters:</strong> Keep gutters clean and properly pitched.
+				</li>
+				<li>
+					<strong>Flexible downspout extensions:</strong> Pitch downspout
+					extensions so water drains completely after it rains or replace them
+					with a metal, non-flexible extension that is pitched to drain fully.
+					Keep the inside free of debris.
+				</li>
+				<li>
+					<strong>Leaky hose spigots:</strong> Fix leak or have it fixed by a
+					professional plumber.
+				</li>
+			</ul>
+
+			<h2>Around the Garden</h2>
+			<ul>
+				<li>
+					<strong>Planter saucers:</strong> Dump the water out every 5-7 days or
+					don't use a saucer at all.
+				</li>
+				<li>
+					<strong>Planters without drainage holes:</strong> Drill holes in the
+					bottom of your planter – it's healthier for your plants.
+				</li>
+				<li>
+					<strong>Self-watering planters:</strong> Tightly seal the watering
+					hole after adding water or use traditional planters with drainage
+					holes.
+				</li>
+				<li>
+					<strong>Wheelbarrows:</strong> Turn wheelbarrows over or store them on
+					end.
+				</li>
+				<li>
+					<strong>Watering Cans:</strong> Empty and store upside down or in a
+					garage or shed.
+				</li>
+				<li>
+					<strong>Rain Barrels:</strong> Cover tops of rain barrels and any
+					overflow holes with tightly fitted screen.
+				</li>
+				<li>
+					<strong>Bird Baths:</strong> Change water at least once a week and
+					brush the inside of the bowl to remove any mosquito eggs.
+				</li>
+				<li>
+					<strong>Ornamental ponds:</strong> Get fish. If that is not an option,
+					you can get a pond fountain to stop the water from being stagnant.
+				</li>
+			</ul>
+
+			<h2>Children's Toys</h2>
+			<ul>
+				<li>
+					<strong>Portable basketball hoops:</strong> Make sure caps for fill
+					holes are in place; replace if lost.
+				</li>
+				<li>
+					<strong>Kiddie pools:</strong> Empty or change water in kiddie pools
+					every 5 - 7 days. Be sure to store indoors or turned over when empty.
+				</li>
+				<li>
+					<strong>Sand boxes:</strong> Drill small drainage holes in the bottom
+					of your sand box.
+				</li>
+				<li>
+					<strong>Big plastic toys, wagons, etc.:</strong> Keep toys turned over
+					or inside when not in use. If water can get inside the toy, so can a
+					mosquito - drill drainage holes in the bottom.
+				</li>
+			</ul>
+
+			<h2>Recreation</h2>
+			<ul>
+				<li>
+					<strong>Boats:</strong> Empty all the water possible. Cover boats in
+					storage with tight tarps or use boat shrink wrap.
+				</li>
+				<li>
+					<strong>Jet skis:</strong> Rinse out the foot depressions with a hose
+					every week. Jet skis can be tightly tarped or stored indoors.
+				</li>
+				<li>
+					<strong>Pools/pool covers:</strong> Keep the top of pool covers free
+					of standing water. If you know of an abandoned home in your
+					neighborhood with an unkempt pool, call the Middlesex County Mosquito
+					Extermination Commission. It may need to be treated or stocked with
+					fish that eat immature mosquitoes.
+				</li>
+			</ul>
+
+			<p>
+				<strong>
+					Don't forget to check behind sheds, under shrubs, decks & porches
+					where containers may hide.
+				</strong>
+			</p>
+			<p>
+				Still have a mosquito problem? You can complete a{" "}
+				<Link to="/contact/service-request">service request here</Link>.
+			</p>
 		</article>
 	);
 }

--- a/apps/public/src/routes/mosquito-surveillance/municipal-packet.tsx
+++ b/apps/public/src/routes/mosquito-surveillance/municipal-packet.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, Link } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/mosquito-surveillance/municipal-packet")(
 	{
@@ -10,7 +10,104 @@ function RouteComponent() {
 	return (
 		<article className="prose lg:prose-base max-w-none">
 			<h1>Municipal Packet</h1>
-			<p>This page is under construction. Please check back soon.</p>
+			<p>
+				To download the full municipal packet, please{" "}
+				<a
+					href="https://middlesexmosquito.sharepoint.com/:b:/g/IQCe8xh5JPY8Qq8IkjwOeUexAd_w-bydOC6LidG5qjFnadE?e=6Rx4bu"
+					rel="noopener noreferrer"
+					target="_blank"
+				>
+					click here
+				</a>
+				.
+			</p>
+			<p>
+				Enclosed you will find New Jersey Department of Environmental Protection
+				Agency approved information about the Middlesex County Mosquito
+				Extermination Commission's operations. This information is provided to
+				be in compliance with N.J.A.C. 7:30-9.10e.
+			</p>
+			<p>This packet contains the following enclosures:</p>
+			<ol>
+				<li>
+					A question and answer sheet on "Mosquitoes – What Everyone Should
+					Know"
+				</li>
+				<li>
+					Fact sheets on{" "}
+					<a
+						href="https://middlesexmosquito.sharepoint.com/:b:/g/IQAAsUz6I6tBTas8NDIz7MybAWOGmKjtQVSONRwe5mr5tDE?e=TIhjep"
+						rel="noopener noreferrer"
+						target="_blank"
+					>
+						DeltaGard®
+					</a>
+					,{" "}
+					<a
+						href="https://middlesexmosquito.sharepoint.com/:b:/g/IQAGYFoWpJj2S7KH16-KTOzsARkyuLQu0PRDd0Ab-zylXbs?e=0iPEHS"
+						rel="noopener noreferrer"
+						target="_blank"
+					>
+						Duet®
+					</a>
+					,{" "}
+					<a
+						href="https://middlesexmosquito.sharepoint.com/:b:/g/IQCAAHgu9bwtSJILsQLUPrE5AZl4XQ1wtcC8JiOnbpIIluo?e=1e5AmF"
+						rel="noopener noreferrer"
+						target="_blank"
+					>
+						Fyfanon®
+					</a>
+					, and{" "}
+					<a
+						href="https://middlesexmosquito.sharepoint.com/:b:/g/IQA8WAM64HkzSYZ8dAej33eKAQFheJOEA3HntjhHQMKkLSE?e=gc2J92"
+						rel="noopener noreferrer"
+						target="_blank"
+					>
+						Zenivex®
+					</a>{" "}
+					Adulticides – the{" "}
+					<Link to="/mosquito-control/mosquito-control-products">
+						mosquito control products
+					</Link>{" "}
+					that may be used by the Commission to control the disease incidence
+					and nuisance levels caused by adult mosquitoes.
+				</li>
+				<li>
+					An example of the{" "}
+					<Link to="/mosquito-control/spray-notice">
+						"Public Notice for Adult Mosquito Control Treatment"
+					</Link>{" "}
+					which will appear in local papers during the mosquito season.
+				</li>
+				<li>
+					<a
+						href="https://middlesexmosquito.sharepoint.com/:b:/g/IQCLzJFwXLQLSaGsaq3XvsZeAUmMrM-lZmc8Bg5lBTX4MIE?e=LJshK5"
+						rel="noopener noreferrer"
+						target="_blank"
+					>
+						Mosquito Prevention and Protection – Fact Sheet
+					</a>
+				</li>
+				<li>
+					<Link to="/mosquito-surveillance/mosquito-source-checklist">
+						Mosquito Habitat Elimination Checklist
+					</Link>
+				</li>
+			</ol>
+			<p>
+				Pursuant to N.J.A.C. 7:30-9.10(e) 2iii, "Municipalities are encouraged
+				to share this information with all residents in their community."
+			</p>
+			<p>
+				If desired, you may contact the Commission to arrange for a speaker to
+				talk about mosquito control in your municipality.
+			</p>
+			<p>
+				The information provided in this packet, our{" "}
+				<Link to="/contact/service-request">Request for Service form</Link> for
+				Middlesex County residents, and more is all available on this website.
+			</p>
 		</article>
 	);
 }

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -1,6 +1,6 @@
+@import url("https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100..900;1,100..900&display=swap");
 @import "tailwindcss";
 @import "tw-animate-css";
-@import url("https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100..900;1,100..900&display=swap");
 
 @source "../../../apps/**/*.{ts,tsx}";
 @source "../../../components/**/*.{ts,tsx}";


### PR DESCRIPTION
## Summary
- **Spray Notice**: full compliance notice with linked insecticide fact sheets, NJAES recommendation, NPIC, and NJPIES resources
- **Aerial Larviciding Notice**: generic treatment notice with Bti/Spinosad product links and Google Maps treatment locations
- **Mosquito Source Checklist**: habitat elimination checklist organized by category with printable PDF link and service request CTA
- **Municipal Packet**: cover letter with linked enclosures (fact sheets, spray notice, prevention sheet, checklist)
- **CSS fix**: moved Google Fonts `@import` before Tailwind imports in `globals.css` to resolve build error

## Test plan
- [ ] Verify all four pages render correctly at their routes
- [ ] Confirm all external links (SharePoint PDFs, NPIC, NJPIES, Google Maps) open in new tabs
- [ ] Confirm all internal links (spray schedule, service request, contact, mosquito control products) navigate correctly
- [ ] Verify no CSS build errors remain
- [ ] Check prose styling is consistent with existing pages (e.g., how-we-control-mosquitoes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)