### PR TITLE
Release: weekly activity chart full-season domain

### DIFF
--- a/.changeset/fix-weekly-activity-chart-domain.md
+++ b/.changeset/fix-weekly-activity-chart-domain.md
@@ -1,0 +1,6 @@
+---
+"public": patch
+"@mcmec/ui": patch
+---
+
+Fix weekly mosquito activity chart rendering when the current year only has a few weeks of data. The week-number domain now spans the union of the current year and the 5-year historical window, so the dashed 5-year average line renders across the full season and the current-year line zero-fills the remaining weeks instead of collapsing to a single point.

--- a/.changeset/fix-weekly-activity-chart-domain.md
+++ b/.changeset/fix-weekly-activity-chart-domain.md
@@ -1,6 +1,0 @@
----
-"public": patch
-"@mcmec/ui": patch
----
-
-Fix weekly mosquito activity chart rendering when the current year only has a few weeks of data. The week-number domain now spans the union of the current year and the 5-year historical window, so the dashed 5-year average line renders across the full season and the current-year line zero-fills the remaining weeks instead of collapsing to a single point.

--- a/apps/admin/CHANGELOG.md
+++ b/apps/admin/CHANGELOG.md
@@ -1,5 +1,12 @@
 # admin
 
+## 0.3.4
+
+### Patch Changes
+
+- Updated dependencies [803e1f7]
+  - @mcmec/ui@1.5.2
+
 ## 0.3.3
 
 ### Patch Changes

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -46,5 +46,5 @@
 		"lint:fix": "biome check --write ."
 	},
 	"type": "module",
-	"version": "0.3.3"
+	"version": "0.3.4"
 }

--- a/apps/central/CHANGELOG.md
+++ b/apps/central/CHANGELOG.md
@@ -1,5 +1,12 @@
 # central
 
+## 0.4.4
+
+### Patch Changes
+
+- Updated dependencies [803e1f7]
+  - @mcmec/ui@1.5.2
+
 ## 0.4.3
 
 ### Patch Changes

--- a/apps/central/package.json
+++ b/apps/central/package.json
@@ -44,5 +44,5 @@
 		"lint:fix": "biome check --write ."
 	},
 	"type": "module",
-	"version": "0.4.3"
+	"version": "0.4.4"
 }

--- a/apps/hr/CHANGELOG.md
+++ b/apps/hr/CHANGELOG.md
@@ -1,5 +1,12 @@
 # hr
 
+## 0.4.3
+
+### Patch Changes
+
+- Updated dependencies [803e1f7]
+  - @mcmec/ui@1.5.2
+
 ## 0.4.2
 
 ### Patch Changes

--- a/apps/hr/package.json
+++ b/apps/hr/package.json
@@ -46,5 +46,5 @@
 		"lint:fix": "biome check --write ."
 	},
 	"type": "module",
-	"version": "0.4.2"
+	"version": "0.4.3"
 }

--- a/apps/notices/CHANGELOG.md
+++ b/apps/notices/CHANGELOG.md
@@ -1,5 +1,12 @@
 # notices
 
+## 0.10.2
+
+### Patch Changes
+
+- Updated dependencies [803e1f7]
+  - @mcmec/ui@1.5.2
+
 ## 0.10.1
 
 ### Patch Changes

--- a/apps/notices/package.json
+++ b/apps/notices/package.json
@@ -49,5 +49,5 @@
 		"lint:fix": "biome check --write ."
 	},
 	"type": "module",
-	"version": "0.10.1"
+	"version": "0.10.2"
 }

--- a/apps/public/CHANGELOG.md
+++ b/apps/public/CHANGELOG.md
@@ -1,5 +1,13 @@
 # public
 
+## 1.5.2
+
+### Patch Changes
+
+- 803e1f7: Fix weekly mosquito activity chart rendering when the current year only has a few weeks of data. The week-number domain now spans the union of the current year and the 5-year historical window, so the dashed 5-year average line renders across the full season and the current-year line zero-fills the remaining weeks instead of collapsing to a single point.
+- Updated dependencies [803e1f7]
+  - @mcmec/ui@1.5.2
+
 ## 1.5.1
 
 ### Patch Changes

--- a/apps/public/package.json
+++ b/apps/public/package.json
@@ -52,5 +52,5 @@
 		"start": "pnpx srvx --prod -s ../client dist/server/server.js"
 	},
 	"type": "module",
-	"version": "1.5.1"
+	"version": "1.5.2"
 }

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @mcmec/ui
 
+## 1.5.2
+
+### Patch Changes
+
+- 803e1f7: Fix weekly mosquito activity chart rendering when the current year only has a few weeks of data. The week-number domain now spans the union of the current year and the 5-year historical window, so the dashed 5-year average line renders across the full season and the current-year line zero-fills the remaining weeks instead of collapsing to a single point.
+
 ## 1.5.1
 
 ### Patch Changes

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -91,5 +91,5 @@
 		"lint": "biome check --write ."
 	},
 	"type": "module",
-	"version": "1.5.1"
+	"version": "1.5.2"
 }

--- a/packages/ui/src/blocks/mosquito-activity-chart.tsx
+++ b/packages/ui/src/blocks/mosquito-activity-chart.tsx
@@ -278,16 +278,22 @@ export function MosquitoActivityCharts({ data }: MosquitoActivityChartsProps) {
 		return [...groups].sort();
 	}, [data]);
 
-	// Compute global week range from the selected year across all groups
+	// Compute global week range across the selected year and the 5-year
+	// historical window so charts still render the average line and zero-fill
+	// the current year when only a few weeks have been uploaded.
 	const weekDomain = React.useMemo((): [number, number] => {
+		const avgYearStart = selectedYear - 5;
+		const avgYearEnd = selectedYear - 1;
 		let min = 53;
 		let max = 1;
 		for (const row of data) {
-			if (row.year === selectedYear) {
-				if (row.week_number < min) min = row.week_number;
-				if (row.week_number > max) max = row.week_number;
-			}
+			const inCurrent = row.year === selectedYear;
+			const inHistory = row.year >= avgYearStart && row.year <= avgYearEnd;
+			if (!(inCurrent || inHistory)) continue;
+			if (row.week_number < min) min = row.week_number;
+			if (row.week_number > max) max = row.week_number;
 		}
+		if (min > max) return [1, 1];
 		return [min, max];
 	}, [data, selectedYear]);
 


### PR DESCRIPTION
## Summary

Releases the weekly mosquito activity chart fix (`@mcmec/ui` 1.5.2) to production. The chart now spans the union of the current year and the 5-year historical window, so the dashed 5-year average renders across the full season and the current-year line zero-fills remaining weeks instead of collapsing to a single point.

Internal-dependency patch bumps cascade through every workspace per the changesets config.

## Test plan
- [ ] Verify the public weekly activity chart on production renders the dashed 5-year average across the full season
- [ ] Verify the current-year line zero-fills remaining weeks rather than collapsing
- [ ] Verify CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)